### PR TITLE
feat(docs): Create consolidated copyright paper and update playbook

### DIFF
--- a/docs/strategy_and_ip/Copyright-Edition-Contextual-Debt-Paper.md
+++ b/docs/strategy_and_ip/Copyright-Edition-Contextual-Debt-Paper.md
@@ -1,0 +1,442 @@
+# **The Unknowable Code: A Framework for Measuring and Mitigating Software Liability**
+
+## **Executive Summary: The Emerging Crisis of Intent**
+
+A new and insidious form of liability is silently accumulating within the digital infrastructure of the global economy. We’ve spent 20 years managing **Technical Debt**—a failure of the "how." But the next decade of *liability* comes from **Contextual Debt**—a "failure of the 'why'". This is a massive, unmanaged risk, creating "amnesiac systems" that are ticking time bombs in every enterprise. This problem is accelerating exponentially. The "context-free, AI-generated code" and fragmented microservices that power modern business are also destroying the human *intent* and *rationale* behind them. Your developers are building "unknowable code" faster than ever.
+
+When this "unknowable" code fails—not if, *when*—it's not a simple bug. It's a "catastrophic system failure," a "data breach," or a "major accounting error". In today's regulatory world, being unable to explain *why* your system did what it did is, in a word, "indefensible".
+
+This report advances the hypothesis that the greatest source of liability in the next decade of software will be the unmanageable accumulation of **Contextual Debt**.
+
+**Contextual Debt** is the compounding liability a software organization incurs from a lack of discernible human intent, architectural rationale, and domain-specific knowledge within its codebase.
+
+This is not a failure of *implementation* (the "how"), like traditional technical debt, but a more profound failure of *intent* (the "why"). It manifests as a quantifiable drag on developer velocity and a direct threat to system security, creating subtle logic flaws that are invisible to traditional analysis tools. While accelerated by the proliferation of context-free, AI-generated code, its accumulation is a systemic risk that can only be managed through proactive disciplines that codify intent (like Architectural Decision Records), automated governance architectures that preserve it, and new quantitative benchmarks (like the Contextual Integrity Score) that measure it.
+
+This analysis establishes a critical distinction between traditional technical debt and this emerging liability. Technical debt, in its original conception, is a failure of the "how"—a suboptimal implementation chosen as a deliberate, short-term tradeoff for speed.1 Contextual Debt, in stark contrast, is a failure of the "why"—the evaporation of the purpose, rationale, and business logic that underpins the code.3 While the former makes a system difficult to change, the latter makes it dangerous to touch.
+
+The accumulation of this debt is being dramatically accelerated by powerful modern trends. The proliferation of AI-generated code introduces vast quantities of logic into codebases without a corresponding transfer of understanding or "theory" to the human developers who must maintain it.4 Simultaneously, the fragmentation of systems into microservice architectures, while beneficial for scalability, disperses architectural rationale and creates siloed knowledge, making a holistic understanding of system behavior nearly impossible.5
+
+The consequences of unmanaged Contextual Debt extend far beyond development friction. They manifest as increased security vulnerabilities, catastrophic system failures, and a direct pathway to corporate liability. In an era where the legal and regulatory shield that has long protected software vendors is being dismantled, the inability to explain the rationale behind a system's design and behavior will become indefensible.7 This report argues that managing Contextual Debt is no longer a matter of engineering best practice; it is a critical component of modern risk management, a non-negotiable aspect of sustainable software engineering, and a core responsibility of corporate governance that will directly impact a company's long-term valuation and legal standing.
+
+## **The Debt Metaphor Revisited: A Foundation in Technical Debt**
+
+To fully grasp the unique threat posed by Contextual Debt, it is essential to first establish a rigorous understanding of the concept from which it derives its name: technical debt. The term has become a ubiquitous, and often misused, part of the software development lexicon. Its journey from a precise financial metaphor to a generic catch-all for "bad code" reveals the need for a new, more specific vocabulary to describe the liabilities accumulating in modern systems.
+
+### **The Genesis of the Metaphor: Ward Cunningham's Strategic Tradeoff**
+
+The debt metaphor was first introduced by American computer programmer Ward Cunningham in a 1992 OOPSLA conference report.1 Working on a portfolio management system, Cunningham sought a way to explain the necessity of refactoring—the process of restructuring existing computer code without changing its external behavior—to non-technical, business-minded stakeholders.9 The financial analogy was both deliberate and potent.
+
+Cunningham's original formulation was not an excuse for sloppy programming but a description of a strategic tradeoff. He wrote, "Shipping first time code is like going into debt. A little debt speeds development, so long as it is paid back promptly with a rewrite".1 The "loan" is the act of releasing software that reflects the team's current, but incomplete, understanding of a problem. This allows the team to gain valuable real-world experience and feedback sooner than they otherwise could.2 The "interest" on this loan is the extra effort and time required to work with this "not-quite-right code" in the future.1 The danger, Cunningham warned, arises when the debt is not repaid, leading to an "unconsolidated implementation" that can bring an entire engineering organization to a standstill under its own weight.1
+
+In a later clarification, Cunningham sharpened this point, stating, "I'm never in favor of writing code poorly, but I am in favor of writing code to reflect your current understanding of a problem, even if that understanding is partial".1 This crucial distinction frames technical debt not as a failure of quality, but as a byproduct of an evolutionary, learning-based development process. The initial implementation is a "first draft" that, through review and use, informs a stronger subsequent version. This original intent, rooted in learning and strategic compromise, stands in stark contrast to the passive, amnesiac nature of Contextual Debt.
+
+### **The Quadrant of Culpability: Martin Fowler's Nuanced Framework**
+
+As the concept of technical debt gained traction, its definition began to broaden. In 2009, influential software developer Martin Fowler introduced a more sophisticated taxonomy, the Technical Debt Quadrant, to bring nuance to the discussion.12 He proposed that debt could be categorized along two axes: **prudent versus reckless** and **deliberate versus inadvertent**.14 This framework is invaluable for dissecting the different ways in which debt can be incurred.
+
+The four quadrants are:
+
+1. **Deliberate and Prudent:** This is the classic form of technical debt as described by Cunningham. A team makes a conscious, strategic decision to take a shortcut—for example, to meet a critical market deadline—fully aware of the consequences and with a plan to address the resulting debt later.14 The decision is calculated, and the potential payoff is deemed greater than the cost of the interest payments.
+2. **Deliberate and Reckless:** This occurs when a team knows what the correct design approach is but chooses to ignore it, opting for a "quick and dirty" solution out of a misguided belief that they don't have time to do it right.14 Fowler argues this is reckless because good design and clean code are ultimately what enable a team to move faster over the long term.14 This category aligns with what others, such as Robert C. "Uncle Bob" Martin, would simply call a "mess" or unprofessionalism.9
+3. **Inadvertent and Reckless:** This is debt incurred through ignorance. A team with insufficient knowledge or skill produces a poorly designed system without even realizing the liability they are creating.14 This "mess" results in crippling interest payments and a long, painful period of repayment.
+4. **Inadvertent and Prudent:** This is perhaps Fowler's most insightful category. He describes this debt as "not just common but inevitable for teams that are excellent designers".14 It arises because teams are constantly learning as they build. A design that was prudent and correct based on the knowledge available at the start of a project may be revealed as suboptimal a year later. The moment the team realizes what the better design *should have been*, they have incurred an inadvertent debt. The metaphor remains useful because the team must still make a strategic choice: continue paying the "interest" of working with the old design, or "pay down the principal" by refactoring to the new, superior design.14 This type of debt, born from evolving understanding of the "how," is the closest conceptual cousin to Contextual Debt, which is born from the complete loss of the "why."
+
+### **The Modern Dilution: Differentiating Debt from Decay**
+
+The very success of the technical debt metaphor has been a primary cause of its dilution. Its power to communicate a complex technical issue in simple financial terms to business stakeholders made it an indispensable tool for engineers seeking resources for refactoring and maintenance.9 However, this widespread adoption led to the term becoming a catch-all for any code that developers found inconvenient, unpleasant, or simply old.9
+
+This dilution obscures critical distinctions. A deliberate, strategic choice to incur debt is fundamentally different from the unprofessionalism that creates a mess.9 One is a calculated risk; the other is a failure of professional responsibility.
+
+Furthermore, it is crucial to distinguish technical debt from **software erosion** or **technical depreciation**. This concept describes the natural decay of a codebase's effectiveness over time, not because of its own flaws, but due to changes in its external environment.18 For example, code that relies on a third-party library becomes a liability when that library is no longer supported. An application built for an older operating system accrues depreciation when a new OS version is released that breaks compatibility.18 This is distinct from debt because it is a passive process; the liability is imposed from the outside, whereas debt implies an active, internal decision, even if inadvertent.
+
+This journey from a precise metaphor to a diluted, generic complaint highlights a critical gap in our vocabulary. The term "technical debt" in its current, broad usage is no longer sharp enough to describe the specific and growing liability of lost intent. When every disliked line of code is labeled as "debt," the term loses its strategic power. This creates the necessity for a new, more precise concept—Contextual Debt—to reclaim the metaphor's communicative power and apply it to a distinct, more insidious class of problems that the original term no longer adequately captures.
+
+## **Defining Contextual Debt: The Liability of Amnesiac Systems**
+
+Contextual Debt represents a fundamental shift in how we must conceptualize liability in software. It moves beyond the mechanics of implementation to the very essence of a system's purpose. Where technical debt describes a system that is poorly constructed, Contextual Debt describes a system that has forgotten why it was built. It is the liability of unknowable code.
+
+### **The Anatomy of Contextual Debt**
+
+At its core, Contextual Debt is "the accumulated, compounding liability from all the un-captured, siloed, or difficult-to-find information across the software development lifecycle".3 It is the organizational friction and risk generated by amnesiac systems. Every time a team member is forced to halt productive work to manually reconstruct the history and purpose of a piece of code, they are paying an interest tax on this debt.3 This liability is built upon three pillars of missing context:
+
+1. **Lack of Discernible Human Intent:** This is the loss of the original purpose, business goals, and user needs that drove the creation of a feature or system. A developer might encounter a complex algorithm for calculating customer discounts but find no record of the business rules it is meant to enforce. Why was this specific formula chosen? Was it to comply with a regional regulation, to support a temporary marketing campaign, or to handle a specific type of enterprise client? Without this intent, any modification to the algorithm risks violating a critical business assumption, potentially leading to revenue loss or customer dissatisfaction.21
+2. **Lack of Architectural Rationale:** This refers to the undocumented and unrecoverable reasons behind significant design choices. Modern systems are a series of complex tradeoffs: the choice of a particular database technology (e.g., SQL vs. NoSQL), the design of an API contract, the decision to use a message queue instead of direct calls, or the selection of a specific cloud service.22 When the rationale for these decisions is lost, the architecture becomes a collection of sacred, unchangeable artifacts. Teams become afraid to refactor or replace components because they do not know what constraints or assumptions the original choice was meant to satisfy. The system becomes brittle and impossible to evolve safely.
+3. **Lack of Domain-Specific Knowledge:** This is the evaporation of the nuanced understanding of the business domain from the codebase itself. Software is a model of a real-world process, and that model is only as good as its understanding of the domain. For example, in an e-commerce system, the distinction between a "Customer" (someone who has made a purchase) and a "Prospect" (someone who has not) is a critical piece of domain knowledge.23 If this distinction is not explicitly encoded in the system's types and variable names, but instead exists only as an implicit assumption in a few scattered functions, the model becomes ambiguous. A new developer tasked with creating a marketing email list could easily—and incorrectly—target both groups, because the code itself has lost the context of this vital business distinction.24
+
+### **The Failure of "Why" vs. "How": A Comparative Framework**
+
+The fundamental difference between technical and Contextual Debt is the axis of failure. Technical debt is a failure of the **"how"**; Contextual Debt is a failure of the **"why"**. While technical debt makes code difficult and expensive to *change*, Contextual Debt makes code profoundly dangerous to *touch*.
+
+Technical debt manifests in the implementation. The code may be convoluted ("spaghetti code"), inefficient, or reliant on outdated dependencies.10 The intent might be clear—for example, a function named calculateSalesTax—but its implementation is suboptimal, making it hard to maintain or debug.
+
+Contextual Debt manifests in the semantics. The code may be perfectly clean, efficient, and well-structured according to a specification that has been lost to time. It is "semantically opaque, architecturally adrift, and lacks a clear, human-centric design philosophy" \[User Query\]. Any attempt to modify it is fraught with peril, as the developer is operating without the critical knowledge of the unstated business rules, architectural constraints, or domain assumptions that the code implicitly enforces.
+
+The following table provides a systematic comparison of these two forms of liability:
+
+| Dimension | Technical Debt | Contextual Debt |
+| :---- | :---- | :---- |
+| **Nature of Failure** | A failure of the **"How"** (suboptimal implementation) | A failure of the **"Why"** (missing or opaque intent) |
+| **Core Metaphor** | A financial loan taken to speed delivery, requiring repayment. | Organizational amnesia; a system that has forgotten its own purpose. |
+| **Primary Cause** | Deliberate tradeoffs, tight deadlines, evolving understanding of a known problem. | Siloed information, team turnover, poor documentation, lack of knowledge capture. |
+| **Typical Manifestation** | Spaghetti code, high cyclomatic complexity, outdated libraries, poor performance. | "Unknowable" code, magic numbers, ambiguous variable names, undocumented architectural choices, lost business rules. |
+| **"Interest" Payment** | Increased time to add features, higher bug rates, difficulty refactoring. | Fear of making changes, inability to onboard new developers, critical production failures from violating hidden assumptions, security vulnerabilities. |
+| **Repayment Strategy** | Refactoring, code cleanup, library upgrades. | Archeological code digs, reverse-engineering intent, interviewing past team members, implementing ADRs and DDD retroactively. |
+| **Relationship to Code** | Syntactically or structurally flawed, but intent may be clear. | Syntactically correct, but semantically and conceptually opaque. |
+
+### **The Silent Accumulation: A Tax Accrued by Default**
+
+A defining characteristic of Contextual Debt is its insidious accumulation. While much technical debt is the result of a conscious decision—a "deliberate and prudent" choice to prioritize speed—Contextual Debt is rarely a conscious choice. It is described as a "silent tax that accrues by default".21
+
+This tax is the natural byproduct of modern, fragmented development ecosystems. The "why" behind a feature is not located in a single place. It is scattered across a constellation of tools: the initial client feedback might be in an email, the feature request in a Jira ticket, the technical discussion in a series of Slack messages, the architectural decision on a whiteboard photo, and the final implementation in Git.21 Each of these tools captures a fragment of the context, but no process exists to synthesize them into a coherent whole that lives with the code. This fragmentation stands in contrast to the failed "Organizational Memory Information Systems" of the 1990s, which were envisioned as centralized, top-down repositories. These systems failed because they were destinations separate from the actual workflow; they became digital graveyards because they fought against the natural, chaotic flow of work.21 Contextual Debt accumulates precisely because our modern tools *are* the workflow, but they are not designed to preserve memory.
+
+This silent accumulation changes the very nature of risk in software development. The primary risk associated with technical debt has traditionally been economic friction—projects take longer and cost more than they should.2 The consequences of Contextual Debt are of a different order of magnitude. When a developer modifies a piece of semantically opaque code, they may do so with the best of intentions. The change may appear correct and pass all automated tests. However, because the developer lacks the original context, their change might inadvertently violate a crucial, unstated compliance rule, a subtle financial calculation, or a critical security assumption. The result is not a simple bug; it is a potential data breach, a major accounting error, or a catastrophic system outage.25 While technical debt can cause a project to go over budget, unmanaged Contextual Debt can cause a company to face regulatory fines, lose customer trust, or suffer an existential security failure. It elevates the problem from a technical concern to a core issue of business governance.
+
+## **The Accelerants: Modern Catalysts for Contextual Debt**
+
+The accumulation of Contextual Debt is not a new phenomenon, but its rate of growth has been supercharged by powerful, contemporary trends in software development. The widespread adoption of AI coding assistants, the architectural paradigm of microservices, and the relentless pursuit of scalability are not merely contributing to the problem; they are acting as powerful catalysts. These forces, often adopted to increase velocity and flexibility, are inadvertently creating a new generation of systems that are more powerful but profoundly less understandable than their predecessors.
+
+### **The AI Co-Pilot's Blind Spot: Comprehension Debt and the Lost "Theory"**
+
+The integration of generative AI into software development environments represents a paradigm shift in productivity. Tools like GitHub Copilot can make developers significantly faster, with some studies showing productivity gains of up to 55%.27 This acceleration, however, comes with a severe and often overlooked side effect: the rapid creation of what can be termed **"comprehension debt"**. This is a specific form of Contextual Debt that arises when developers "don't comprehend what the system does anymore" because they did not build the foundational understanding in the first place.4
+
+This phenomenon can be understood through the lens of computer scientist Peter Naur's concept of "theory building".4 Naur argued that a program is not merely the source code itself, but also the "theory" or mental model of the problem and its solution that exists in the minds of the developers who built it. When that team dissolves, the theory is lost, and while the code may continue to run, any attempt to modify it is perilous because the new team lacks the requisite understanding.4 AI coding assistants create an exponential version of this problem. To fulfill a prompt, the AI builds a temporary, internal "theory" of the codebase, identifying connections and necessary changes. It then generates the code and, crucially, its theory is "immediately lost".4 The human developer, by accepting the code without deep engagement, never builds this essential mental model. The "why" behind the AI's solution is never transferred, creating an immediate and permanent pocket of Contextual Debt.
+
+This AI-accelerated debt has several distinct consequences:
+
+* **Lack of Global Context:** AI tools operate at the level of code snippets and functions. They lack a true understanding of the broader system architecture, long-term business goals, or nuanced domain constraints. The code they generate may be locally correct but globally incoherent, introducing subtle inconsistencies or violating unstated architectural principles.29
+* **Increased Code Churn and Duplication:** Empirical data indicates that the use of AI assistants has led to a doubling of "code churn"—code that is quickly added and then modified or removed—and a sharp decline in code reuse.27 Developers, enabled by the AI's speed, are more likely to generate a new, slightly different version of an existing function than to find and refactor the original. This practice leads to a bloated, fragmented, and increasingly unknowable codebase.30
+* **Accumulation of Knowledge Debt:** Over time, the team becomes responsible for maintaining a significant volume of code that "nobody actually wrote".27 This creates a dangerous knowledge gap that snowballs with each new AI-generated feature, making the system progressively more opaque and fragile.
+
+### **The Distributed Monolith: Architectural Fragmentation in Microservices**
+
+Microservice architectures have become a dominant paradigm for building large-scale systems, promising high maintainability, scalability, and the ability for teams to develop and deploy their services independently.31 However, when poorly implemented, this architectural style can become a primary driver of Contextual Debt. The risk is that instead of a set of loosely coupled, independent services, organizations inadvertently create a **"distributed monolith"**—a system where services are de jure separate but de facto tightly coupled through a web of complex, undocumented, and brittle dependencies.32
+
+The core issue is the "potential loss of the bigger architectural picture".5 In a traditional monolithic application, the architectural rationale, however well or poorly documented, is centralized. In a microservices ecosystem, that rationale becomes fragmented across dozens or even hundreds of services, often owned by different teams operating in semi-autonomy. The overarching "why" of the system's holistic design—how the pieces are meant to fit together to achieve a business outcome—is easily lost.
+
+This fragmentation is a form of architectural debt that manifests in several ways:
+
+* **Communication Layer Complexity:** Business logic that should reside within a specific service often leaks into the communication layer (e.g., API gateways, service meshes), making the interactions between services opaque and difficult to reason about.33
+* **Point-to-Point Proliferation:** A high number of direct, point-to-point connections between services creates a "dependency hell" where a change in one service can have unforeseen cascading effects across the system.33
+* **Siloed Knowledge:** The very structure of a microservices organization, with distinct teams owning individual services, is a natural breeding ground for the siloed knowledge that is a root cause of Contextual Debt.19 The team that owns the "Orders" service may have no deep understanding of the constraints within the "Inventory" service, leading to integrations that are functional but violate subtle, critical business rules.
+
+### **The Scalability Trap: When Future-Proofing Creates Present-Day Liability**
+
+Scalability—the ability of a system to handle a growing amount of work—is a critical non-functional requirement for any modern business. A system that cannot scale effectively will suffer from performance degradation, become more vulnerable to security threats, and ultimately prevent the business from seizing market opportunities.34
+
+However, the pursuit of scalability can itself become a significant source of Contextual Debt. The "scalability trap" occurs when teams engage in premature or excessive optimization, designing architectures for a hypothetical massive scale that may never materialize.22 These highly "scalable" architectures often introduce immense complexity in the form of intricate multi-level caching strategies, complex message queues, event-sourcing patterns, and database sharding logic.36
+
+The Contextual Debt arises when the rationale for this added complexity is inevitably lost. A developer joining the team years later will encounter a labyrinthine system but will have no record of *why* it was designed that way. Was the complex caching layer implemented to solve a specific performance bottleneck that has since been rendered obsolete by a database upgrade? Was the event-sourcing pattern chosen to support a predicted user load that was an order of magnitude higher than reality? Without this context, the architecture becomes a rigid, unknowable liability. It is too complex to be easily understood and too risky to be simplified or removed, as the team cannot be certain what critical function it might still be serving. The prudent decision to build for the future, if its context is lost, becomes a crippling debt in the present.
+
+These three accelerants do not operate in isolation; they form a vicious cycle of context destruction. A premature scalability decision creates an overly complex architecture whose rationale is not documented. This system is then implemented using microservices, which fragments the remaining architectural knowledge across siloed teams. Finally, a developer on one of those teams uses an AI assistant to add a feature. The AI, lacking the global context of the undocumented, fragmented architecture, generates code that is locally correct but violates a core, unstated principle of the system. This change passes its local tests and is deployed, only to cause a catastrophic, system-wide failure that is nearly impossible to debug because the original intent is lost, the architecture is fragmented, and the offending code was generated by a machine with no memory of its decision. Each accelerant amplifies the destructive potential of the others, creating a perfect storm for the accumulation of unknowable code.
+
+## **The Consequences: From Development Friction to Corporate Liability**
+
+The accumulation of Contextual Debt is not an abstract technical concern; it has tangible, high-stakes consequences that ripple through an organization. The "interest payments" on this debt begin as a drag on operational efficiency but can escalate into severe security vulnerabilities and, ultimately, significant corporate and legal liability. Understanding this progression is critical for reframing Contextual Debt from an engineering problem to a C-suite-level risk.
+
+### **The Interest Payments: Quantifying the Operational Drag**
+
+The most immediate and persistent consequence of Contextual Debt is a severe degradation of an organization's ability to execute. This operational drag manifests in several key areas:
+
+* **Reduced Velocity and Innovation:** The primary interest payment is a dramatic slowdown in development velocity. As the codebase becomes more opaque, developers must spend an increasing percentage of their time on "software archeology"—painstakingly trying to reverse-engineer the purpose and function of existing code rather than building new, value-creating features.25 This directly impacts time-to-market for new products and services, erodes competitive advantage, and stifles a company's capacity for innovation.26
+* **Increased Complexity and Defect Rates:** A system without a discernible design philosophy or clear intent is a system where complexity grows unchecked. Every new feature added to an unknowable codebase is a patch on a mystery, increasing the system's entropy. Changes become more error-prone and are more likely to introduce subtle defects or regressions in seemingly unrelated parts of the system.20 This leads to a decline in software quality, system instability, and a degradation of the customer experience.38
+* **Onboarding and Talent Retention Challenges:** A codebase laden with Contextual Debt is a hostile environment for new engineers. Without clear documentation of intent and rationale, onboarding becomes a slow and frustrating process of draining "tribal knowledge" from a handful of senior engineers who may still hold fragments of the system's original context.21 This not only makes the organization less efficient but also leads to burnout among senior staff and high turnover rates for frustrated new hires.11 This, in turn, accelerates the very knowledge loss that created the problem, creating a self-perpetuating cycle of decay.
+
+### **The Ticking Time Bomb: Contextual Debt as a Security Threat Multiplier**
+
+The connection between software quality and security is well-established, but Contextual Debt represents a particularly potent threat multiplier. The central axiom is simple: **unknowable code is unsecurable code**. When developers cannot reason about the intended behavior of a system, they cannot effectively secure it against unintended behaviors.
+
+Contextual Debt directly undermines cybersecurity posture in several critical ways:
+
+* **Difficulty in Remediating Vulnerabilities:** When a new vulnerability is discovered in a third-party library or a common software pattern, remediation requires developers to understand where and how that component is used throughout their system. In a system with high Contextual Debt, this becomes a monumental task. The increased complexity and lack of clear architectural understanding make it significantly harder to locate all instances of the vulnerability, assess the true risk, and apply a patch without causing unintended side effects.25
+* **Inadvertent Introduction of New Flaws:** The act of modifying opaque code is a primary vector for introducing new security vulnerabilities. For example, a developer tasked with "optimizing" a data access function might simplify the logic, inadvertently removing a subtle but critical authorization check that was never explicitly documented but was essential for preventing data leakage.25 The code "works," but it is now insecure, and the flaw is unlikely to be caught by standard testing that does not know to look for the violation of a forgotten rule.
+* **A Fertile Environment for Exploits:** Complex, poorly understood systems are a breeding ground for security flaws. Issues like insecure configurations, improper error handling that leaks sensitive information, or broken access control logic are often not the result of a single, obvious bug, but the emergent property of a system whose components interact in ways that no one on the team fully comprehends.7 High Contextual Debt creates the ideal conditions for these types of vulnerabilities to fester undetected.
+
+### **The New Legal Paradigm: The End of Software's Liability Shield**
+
+For decades, the software industry has operated under a unique liability shield, largely protected by End-User License Agreements (EULAs) and legal precedents that placed the burden of risk on the consumer.7 That era is decisively coming to an end. A significant global shift in policy and legal thinking is underway, aimed at holding software vendors accountable for the security and integrity of their products.
+
+This shift is being driven by key policy initiatives:
+
+* **The U.S. National Cybersecurity Strategy (NCS):** Released in 2023, the NCS explicitly calls for a fundamental rebalancing of liability. It states that vendors should be "held liable when they fail to live up to the duty of care they owe" to their customers and advocates for shifting liability onto producers who fail to take "reasonable precautions" to secure their software.7
+* **The E.U. Cyber Resilience Act (CRA):** This proposed regulation in the European Union seeks to establish a form of liability for all "products with digital elements" by requiring vendors to attest to their adherence to a set of basic cybersecurity practices throughout the product's lifecycle.42
+
+The emerging consensus is a move away from strict liability—where a vendor is liable for any harm caused by their product, regardless of fault—toward a **negligence standard**.8 Under this standard, the central legal question will be whether the software vendor exercised a reasonable "duty of care" in the development, maintenance, and deployment of their product.
+
+This is where the concept of Contextual Debt transitions from a technical issue to a critical legal one. This report posits the central legal argument that **the presence of significant, unmanaged Contextual Debt within a software system is prima facie evidence of a failure to meet a reasonable duty of care.** In the aftermath of a significant security breach or system failure, investigators, regulators, and plaintiffs' attorneys will ask not only *what* happened, but *why*. They will demand to see the records demonstrating the rationale behind key architectural decisions. They will ask for the evidence that security tradeoffs were consciously evaluated. They will probe whether the organization had a coherent and consistent understanding of its own system's behavior.
+
+An organization crippled by Contextual Debt will be unable to answer these questions. A company that cannot explain why its own authentication system was designed a certain way, or what business rules a critical financial calculation is supposed to enforce, cannot plausibly claim to have been reasonably diligent in its construction and maintenance. Contextual Debt thus becomes a direct, measurable proxy for legal and financial liability.
+
+This evolution in liability is already being foreshadowed by the regulatory push for Software Bills of Materials (SBOMs), which require vendors to provide a manifest of all components in their software.7 However, SBOMs only answer the question of "what" is in the code. The next logical step in regulatory and legal scrutiny will be to ask "why." The demand will move beyond component lists to something akin to an "Architectural Bill of Materials" or a "Decision Bill of Materials"—artifacts that document the rationale, tradeoffs, and intent behind the system's design. The practices that mitigate Contextual Debt are, therefore, not merely good engineering hygiene; they are the proactive creation of the evidentiary record that will be required to defend against the coming wave of software liability claims.
+
+## **Contextual Debt as a Direct Security Liability**
+
+The accumulation of Contextual Debt is not merely a drag on productivity; it has transformed into an active, escalating, and largely invisible security liability. This is because the foundational principle of all cybersecurity is the enforcement of *intent*. A security policy is a codified expression of an organization's *intended* behavior for a system. An organization that does not understand *why* its own systems behave as they do has lost the ability to define, let alone enforce, intended behavior. You cannot secure what you do not understand.
+
+AI coding agents are high-speed factories for this specific form of debt. Without explicit guidance and a deep, human-like understanding of context, an LLM may "inadvertently strip away critical safeguards or introduce subtle flaws in pursuit of perceived improvement". This act of "improving" code by removing seemingly redundant checks—checks that a human engineer placed for a specific, unstated security reason—is the "why" evaporating *during the moment of creation*.
+
+### **The Failure of Traditional Security Tooling**
+
+It is imperative to distinguish this new risk class from traditional vulnerabilities. The industry has spent two decades focused on **Technical Debt**, which is a failure of the "how"—a suboptimal implementation. This debt class leads to well-understood, pattern-based vulnerabilities like SQL injections or the use of stale libraries with known CVEs. The entire "Shift Left" security apparatus, dominated by Static Application Security Testing (SAST) and Dynamic Application Security Testing (DAST), was engineered to find these implementation flaws.
+
+**Contextual Liability**, by contrast, is a failure of the "why". It does not manifest as a common vulnerability pattern but as "subtle business logic flaws" and "complex access control issues". An AI agent, lacking the human's "why" entirely, can generate a subtle logic flaw that *looks* like a safe, framework-mitigated pattern. This creates the perfect camouflage: a flaw in *intent* (Contextual Liability) that is perfectly disguised as a *valid implementation* (the "how"). This vulnerability is structurally invisible to the SAST scanner, which sees no pattern violation.
+
+### **Case Study: The Fine-Grained Authorization (FGA) Tipping Point**
+
+Nowhere is the danger of Contextual Liability more acute than in the industry's most advanced security systems: modern Fine-Grained Authorization (FGA). An FGA system is powerful because it makes decisions based on the *relationship* between a subject (a user) and an object (a resource). Crucially, an FGA system is not merely a security layer applied atop an application; it is a *codified model of the business itself*. Unlike authentication, which can be decoupled, authorization is "tightly coupled with business logic".
+
+This creates a profound realization. FGA systems, when implemented correctly, are the *antidote* to Contextual Debt. A well-designed FGA model serves as a living, executable, and centralized database of the "why"—the exact business relationships and architectural rationale that define "who can do what." The advent of AI coding agents tragically *inverts* this. Instead of being the *solution* for Contextual Debt, the FGA model is now its *primary victim*. We are now asking AI agents—systems defined by their fundamental lack of "domain-specific knowledge"—to write and modify these hyper-sensitive, context-dependent models.
+
+> [*Legal Note:*] When an AI "hallucinates" a business rule and codifies it as a security policy, it is committing the most dangerous possible injection of Contextual Debt. This action creates a direct pathway to liability, as the very system designed to be the fortress of intent has been poisoned with "semantically opaque" rules that look correct but are logically, and catastrophically, flawed. A post-breach legal discovery process would almost certainly identify this as a failure to meet the "duty of care."
+
+### **The Cyber-Sentinel: A New Paradigm for Security**
+
+The inescapable conclusion is that our current security paradigm is broken. We cannot solve an AI velocity problem with more human review or more static scans. We must fight a new class of AI-generated flaws with a new class of AI-driven defense. This calls for a "Cyber-Sentinel Agent"—a specialized evaluator agent designed not to find *bugs* but to audit for *intent*. This new category of "AI-Native SAST" is built from the ground up not to match patterns, but to "reason across users, data, and permissions" and to be "crucial for catching vulnerabilities like IDOR and Broken Object-Level Authorization (BOLA)".
+
+## **Proactive Management: Strategies for Building Systems with Memory**
+
+Confronting the challenge of Contextual Debt requires a deliberate shift from passive accumulation to proactive management. The goal is to build systems with institutional memory, where the "why" is treated as a first-class citizen of the software development lifecycle, just as important as the "what" and the "how." This requires adopting a set of disciplines and cultural practices designed to codify intent, embed domain knowledge, and enforce human oversight.
+
+### **Codifying the "Why": Architectural Decision Records (ADRs) as Institutional Memory**
+
+The most direct and powerful tool for combating the loss of architectural rationale is the **Architectural Decision Record (ADR)**. An ADR is a lightweight, structured document that captures a single, architecturally significant decision, along with its context and consequences.43 A collection of ADRs for a project forms a "decision log," which serves as an immutable, chronological record of the architecture's evolution.43
+
+ADRs are a direct antidote to the second pillar of Contextual Debt. They explicitly document:
+
+* **The Context:** The problem being solved, the constraints, and the forces at play when the decision was made.
+* **The Decision:** The specific choice that was made (e.g., "We will use PostgreSQL as the primary database for the inventory service").
+* **The Consequences:** The expected outcomes of the decision, including the accepted tradeoffs and any new risks or requirements that arise from it.
+* **Considered Alternatives:** A brief description of the other options that were evaluated and the reasons they were rejected. This is crucial for preventing future teams from re-litigating old debates.45
+
+To be effective, the implementation of ADRs should follow several best practices:
+
+* **Focus on Significance:** ADRs should be created only for "architecturally significant" decisions—those that are high-cost to change or that affect the system's core structure and non-functional requirements. This prevents the process from becoming an exercise in bureaucratic overhead.43
+* **Use a Simple, Consistent Template:** Adopting a lightweight, consistent template (such as the popular format proposed by Michael Nygard) makes creating and reading ADRs easier.44
+* **Integrate into Workflow:** ADRs should be treated as code. They should be stored in the same version control system (e.g., Git) as the source code they describe, allowing them to be reviewed and updated as part of the normal development process. They should be referenced in code reviews to ensure that new code complies with established architectural principles.43
+* **Embrace Immutability:** Once an ADR is accepted, it should not be changed. If a decision needs to be reversed or modified, a new ADR should be created that explicitly supersedes the old one. This preserves the historical record of *why* the original decision was made, which is itself valuable context.43
+
+### **Embedding the "What": Domain-Driven Design (DDD) as a Bulwark Against Ambiguity**
+
+While ADRs address architectural rationale, **Domain-Driven Design (DDD)** is a powerful discipline for combating the loss of domain-specific knowledge and human intent. DDD is a software development approach that centers on creating a rich, sophisticated model of the business domain and embedding that model directly into the code.48 It seeks to make the software a faithful and explicit reflection of the business it serves.
+
+Two core DDD principles are particularly effective at mitigating Contextual Debt:
+
+1. **Ubiquitous Language:** DDD insists on the creation of a shared, unambiguous vocabulary that is used consistently by everyone involved in the project—domain experts, developers, product managers, and QA engineers. This "Ubiquitous Language" is not just for meetings and documents; it is used directly in the code for class names, methods, and variables.24 When the business talks about a "Premium Customer," the code should contain a PremiumCustomer class. This practice eliminates the ambiguity and mental translation that is a primary source of Contextual Debt, ensuring that the code's intent is clear and directly tied to the business reality.48
+2. **Bounded Contexts:** DDD recognizes that in any complex business, concepts can have different meanings in different contexts. For example, the concept of a "Product" in the sales and marketing context (focused on pricing, features, and campaigns) is very different from a "Product" in the shipping and logistics context (focused on weight, dimensions, and warehouse location).24 A Bounded Context is an explicit boundary within which a particular domain model and its Ubiquitous Language are consistent and well-defined. By dividing a large, complex system into a set of clearly defined Bounded Contexts, DDD prevents ambiguity and makes the overall complexity manageable.24
+
+DDD is not just a set of technical patterns; it is a discipline of continuous collaboration. It requires developers and domain experts to work closely together in modeling sessions to ensure that the software's "theory" is shared, accurate, and constantly validated against the real world.24
+
+### **Human-in-the-Loop Governance for AI-Generated Code**
+
+The acceleration of Contextual Debt by AI coding assistants cannot be stopped by banning these tools; their productivity benefits are too great. Instead, organizations must implement a robust governance framework built on the principle of **human-in-the-loop accountability**. The core tenet is that the development team must retain full intellectual ownership and deep understanding of every line of code in their system, regardless of its origin.27 The AI is a powerful tool, but the human developer remains the responsible architect.
+
+An effective framework for responsible AI usage includes:
+
+1. **Mandatory, In-Depth Code Reviews:** All AI-generated code must be subject to the same, if not more rigorous, code review process as human-written code. The review must go beyond simple correctness ("Does it work?") to assess clarity, maintainability, adherence to the Ubiquitous Language, and compliance with documented architectural decisions (ADRs).27
+2. **Prompting for Context:** Developers should be trained to write prompts that provide the AI with as much context as possible. This includes specifying constraints, referencing existing design patterns, and even asking the AI to explain the rationale behind its generated solution.
+3. **Refactor, Don't Just Accept:** AI-generated code should be treated as a first draft or a suggestion. The primary role of the human developer shifts from pure code generation to that of a critical editor and integrator. Their job is to refactor, simplify, and thoughtfully integrate the AI's output into the broader system, building their own mental "theory" of the code in the process.30
+4. **Document AI-Driven Decisions:** If a significant or novel solution is implemented using AI-generated code, that fact should be documented. Ideally, an ADR should be created to capture the prompt used, the code that was generated, and the human rationale for accepting and integrating it into the system.
+
+Implementing these strategies is not a simple matter of adopting new tools or processes; it requires a profound cultural and organizational shift. It necessitates breaking down the silos that separate technology from the business and legal departments. It demands a redefinition of developer productivity, moving away from crude metrics like "lines of code" or "features shipped" and toward a more mature understanding that values "lines of understood, defensible code." An organization's ability to mitigate Contextual Debt is, therefore, a direct reflection of its engineering culture and its commitment to clarity, communication, and shared understanding over the deceptive allure of raw speed.
+
+## **The Developer Experience of Contextual Debt: A New Market for Tooling**
+
+While "liability" suggests a passive, abstract risk, the business impact of contextual debt is direct, quantifiable, and severe. It is not a hypothetical future problem but a present-tense drain on the three pillars of engineering health: productivity, quality, and talent retention. High contextual debt manifests as a direct, measurable tax on developer productivity. When the *intent* behind a piece of code is missing, or the *rationale* for an architectural choice is undocumented, developers are forced to become code archaeologists instead of builders.
+
+The following table outlines the quantifiable business impact of high contextual debt:
+
+| Metric | Impact of High Contextual Debt | Financial Consequence |
+| :---- | :---- | :---- |
+| **Developer Productivity** | 19% productivity loss vs. teams with high-quality documentation. Up to 33% of developer time spent on technical debt. | Lost engineering hours; direct inflation of R\&D budget. |
+| **Time-to-Market** | 18% longer to release new features compared to industry peers. | Delayed revenue, loss of competitive advantage, reduced market share. |
+| **Defect Rate & Quality** | 21% increase in defect rates. | 10x cost multiplier to fix bugs found late in the cycle; brand damage. |
+| **New Hire Onboarding** | 3 weeks of additional ramp-up time required for new developers. | Increased cost-per-hire, reduced team velocity, strain on senior staff. |
+| **Engineer Turnover** | 25-35% higher turnover rate in teams with high technical debt. | $50,000 \- $100,000 replacement cost per senior developer; loss of institutional knowledge. |
+
+### **The "Contextual Debt Analyzer": A New Class of Tooling**
+
+This new, acute problem—AI-generated code overwhelming human context—requires a new class of tooling. This new category, the "Contextual Debt Analyzer," is not just an add-on but the logical and necessary third step in the evolution of automated code analysis.
+
+| Tool Category | Primary Function | Scope of Analysis | Example Tools |
+| :---- | :---- | :---- | :---- |
+| **Gen 1: Linters** | Enforce Code Style & Syntax | Single File | ESLint, Prettier |
+| **Gen 2: SAST / Quality Platforms** | Find Bugs & Security Vulnerabilities | Project / Repository | SonarQube, Snyk, Checkmarx |
+| **Gen 3: Contextual Analyzers** | Enforce Intent, Rationale, & Domain Knowledge | Entire Codebase \+ Org. Knowledge | Qodo, CodeRabbit, Greptile |
+
+These platforms automate intent, rationale, and domain knowledge. They are "context-centric," not just "code-centric." They analyze new code against the organization's collective knowledge: its existing codebase, its architectural standards, its documented decisions, and its domain-specific language. Their scope is the entire, a multi-repository codebase and the human knowledge that surrounds it.
+
+> [*Legal Note:*] The outputs of a Contextual Debt Analyzer, particularly its automated reports on architectural violations and missing intent, could serve as crucial evidence in a legal setting. These reports provide a time-stamped, objective record of whether an organization was actively monitoring and managing the clarity and defensibility of its AI-generated code, directly supporting a "duty of care" defense.
+
+## **A Call for a New Standard: The Contextual Integrity Score (CIS)**
+
+The accumulation of Contextual Debt renders traditional software quality benchmarks not just insufficient, but actively misleading. Metrics like Cyclomatic Complexity and Maintainability Index fail to capture the "why" behind the code, and test coverage has become a "vanity metric" that validates execution, not semantic correctness. To manage this new risk, we must develop a benchmark capable of quantifying intent itself.
+
+This paper proposes the **Contextual Integrity Score (CIS)**. The CIS is a standardized, composite metric designed to provide a quantifiable, multi-dimensional assessment of a software artifact's contextual integrity. It directly measures the accumulation of Contextual Debt by evaluating the code's alignment with human intent, its architectural conformance, and the semantic validity of its testing. The CIS is envisioned as an essential "nutritional label" for AI-generated code, composed of three distinct pillars:
+
+### **The Contextual Integrity Score (CIS) v0.1**
+
+The Contextual Integrity Score (CIS) is a numerical score from 1-100 that quantifies the legal and operational risk associated with a given code change. It is calculated based on three equally-weighted inputs:
+
+1.  **Rationale Integrity (33.3%):** This measures the clarity and accessibility of the *why* behind the code.
+    *   **Measurement:** A score is generated based on the presence and quality of a link between a code commit and a documented source of intent (e.g., a project management ticket, an Architectural Decision Record (ADR), or a formal specification). A commit with no discernible link automatically receives a score of 0. Quality is assessed by an LLM trained to evaluate the clarity and completeness of the linked rationale.
+
+2.  **Architectural Integrity (33.3%):** This measures the code's adherence to the project's established architectural principles and patterns.
+    *   **Measurement:** The score is determined by statically analyzing the code's dependencies and structure against a predefined "Context Graph" of the system's architecture. Violations, such as a backend service directly calling a frontend component, will decrease the score. The "Context Graph" is a formal representation of the intended architecture, maintained as part of the project's documentation.
+
+3.  **Testing Integrity (33.3%):** This measures the sufficiency of the testing coverage in relation to the documented intent.
+    *   **Measurement:** This is not just about code coverage percentage. The score is calculated by evaluating whether the tests validate the specific requirements outlined in the documented rationale. An LLM will be used to compare the test cases against the acceptance criteria of the linked ticket or ADR. Code can have 100% line coverage but a low Testing Integrity score if its tests do not address the stated business goal.
+
+The following tables provide a high-level overview of the scoring rubric for each component of the CIS.
+
+**Rationale Integrity Score (RIS) Scoring Rubric**
+
+| Score | Rating | Description |
+| :---- | :---- | :---- |
+| **1-2** | **Opaque / Contradictory** | The code's purpose is not discernible and may actively contradict a documented business rule. |
+| **3-4** | **Misaligned** | The code's purpose is inferred but is misaligned with the domain, solving the literal text of a prompt, not the latent business problem. |
+| **5-7** | **Traceable** | The code's purpose is clear and aligns with requirements, allowing an engineer to manually trace it back to a functional requirement. |
+| **8-10** | **Explicit & Aligned** | The code's purpose is explicitly and accurately tied to the business rationale, often referencing the specific requirement ID or user story it implements. |
+
+**Architectural Integrity Score (AIS) Scoring Rubric**
+
+| Score | Rating | Description |
+| :---- | :---- | :---- |
+| **1-2** | **Chaotic** | The code is both locally complex and globally non-compliant, a "big ball of mud." |
+| **3-5** | **Brittle / Deceptive** | **(The "AI-Failure" Case)** The code *appears* clean on a local level but is fundamentally wrong, violating core architectural rules. |
+| **6-8** | **Compliant** | The code is architecturally sound and passes all conformance rules, though it may be locally complex. |
+| **9-10** | **Sound & Maintainable** | The code is both locally clean and globally sound, the gold standard for sustainable code. |
+
+**Testing Integrity Score (TIS) Scoring Rubric**
+
+| Score | Rating | Description |
+| :---- | :---- | :---- |
+| **1-2** | **Vanity Coverage** | **(The "Semantic Gap" Case)** This test suite may have >90% code coverage but validates almost none of the actual requirements. |
+| **3-5** | **Gappy** | The tests are relevant and cover the "happy paths" of the core requirements, but they fail to "stress-test" the component. |
+| **6-8** | **Robust** | The test suite is semantically sound and covers all critical business requirements and their most common behavioral paths and edge cases. |
+| **9-10** | **Semantically Validated** | The test suite fully validates the *intent* and *behavior* of the requirements. |
+
+> [*Legal Note:*] A standardized CIS, if adopted, could become a key piece of evidence in software liability cases. An organization's ability to produce high CIS scores for its critical systems would serve as a powerful demonstration of its commitment to a "duty of care," while consistently low scores could be interpreted as negligence.
+
+## **Automated Governance: The "Agent-as-a-Judge"**
+
+The speed and scale of AI-generated software have rendered traditional, human-centric governance models obsolete. The manual code review, or a simple human-in-the-loop (HITL) checkpoint, is fundamentally incapable of scaling to meet the output of a team of AI agents. This crisis necessitates a philosophical shift. To effectively govern systems generated by AI, we must deploy AI-based governance. This requires moving from a paradigm of reactive, manual auditing to one of proactive, automated, and scalable AI-native governance.
+
+We have developed the **Agent-as-a-Judge**, a proprietary AI that *evaluates* code, not just writes it. While other AIs accelerate the *problem*, our 'Agent' acts as an 'automated governance system' that *preserves* intent, spots "missing rationale", and stops catastrophic failures *before* they're deployed.
+
+### **The Agent-as-a-Judge v0.1**
+
+The Agent-as-a-Judge is a specialized, autonomous AI agent designed to act as a "critic" and gatekeeper within the CI/CD pipeline. Its primary function is to prevent code with low Contextual Integrity from being merged into the main branch.
+
+**Conceptual Workflow:**
+
+1.  **Trigger:** The Agent-as-a-Judge is triggered upon the creation of a new pull request.
+2.  **Analysis:** It reads the pull request's code and its associated commit messages.
+3.  **CIS Calculation:** The agent calculates the Contextual Integrity Score (CIS) for the proposed change by performing the three integrity checks described above.
+4.  **Enforcement:**
+    *   It automatically fails the build if the commit has no link to a documented source of intent (e.g., a ticket, ADR).
+    *   It provides a detailed report in the pull request, highlighting specific areas of Rationale, Architectural, or Testing debt.
+    *   It can be configured with a minimum acceptable CIS threshold (e.g., 80/100). If the score is below the threshold, the build fails.
+5.  **Training Data:** The underlying AI models for the agent will be trained on the proprietary dataset gathered during the Phase 1 consulting engagements.
+
+### **Architecting Accountability: The "Glass Box" Approach**
+
+A governance philosophy like "Agent-as-a-Judge" is operationally useless if applied to an ungovernable architecture. A single, monolithic AI agent, even a highly capable one, remains a "black box". Its internal reasoning, decision-making trajectory, and the precise moment it incurred contextual debt are opaque and fundamentally unauditable. Applying a "judge" to its final output is a post-mortem, not a preventative measure.
+
+The solution is to adopt a paradigm of multi-agent systems. The prime architectural candidate for implementing this "glass box" governance is the **"Orchestrator-Worker" (O-W) pattern**. The Orchestrator-Worker pattern is a multi-agent architecture where a central "lead agent" (the Orchestrator) coordinates the process while "delegating to specialized subagents" (the Workers) that operate in parallel.
+
+This pattern is inherently auditable. In a monolithic "black box" system, the agent's "decision-making process" is a hidden, internal state. In the O-W architecture, this entire process is *externalized*. The "full reasoning trace" of the system is not a cryptic internal log; it is the explicit, observable communication log between the Orchestrator and the Workers. Every "decision" is a "message". Every "sub-task" is a discrete, logged instruction.
+
+The following table provides a direct comparison between the traditional monolithic model and the multi-agent Orchestrator-Worker model across key governance metrics.
+
+| Feature | Monolithic Agent System (The "Black Box") | Orchestrator-Worker System (The "Glass Box") |
+| :---- | :---- | :---- |
+| **Auditability** | **Opaque.** Reasoning is an internal, hidden state. Auditing relies on post-hoc analysis of the final output. | **Traceable by Design.** Reasoning is an *externalized communication log* between agents. The "full reasoning trace" is a native artifact. |
+| **Accountability** | **Ambiguous.** Failures are monolithic. "Who" is to blame? The single agent. | **Attributable.** Failures are modular. Accountability can be traced to the specific worker agent (e.g., "Code-writer" or "Auditor") that failed its task. |
+| **Context Preservation** | **Low (Drifts).** Context is ingested as a single, large prompt. Prone to "contextual debt" as "generic assumptions" overtake specific domain rules. | **High (Specialized).** Context is distributed to specialized agents. A "payments agent" *only* knows payments, preserving domain integrity. |
+| **Failure Mode** | **Catastrophic.** A single point of failure (e.g., a "hallucination") can corrupt the entire process, leading to "error compounding". | **Localized & Modular.** A single worker agent can fail, but the Orchestrator can detect this, isolate the failure, and re-assign the task. |
+| **Governance Model** | **External & Reactive.** A human (or separate AI) must review the final output *after* contextual debt is incurred. | **Internal & Proactive.** Governance (e.g., an evaluator "Green Agent") is a *worker* within the system, auditing *during* the process. |
+
+### **Agentic Evaluation: A New Paradigm for Quality and Safety**
+
+Within the Orchestrator-Worker framework, an evaluator agent is the primary engine of governance. Its mandate is comprehensive: to "ensure that agents avoid harmful or unsafe behavior, maintain user trust through predictable and verifiable outputs, and resist manipulation or misuse". This mandate can be decomposed into two primary pillars: automated auditing for code quality and automated "red teaming" for trust and safety.
+
+The first pillar, quality, addresses the functional correctness and maintainability of the generated code. A key mechanism for this is **Reinforcement Learning from AI Feedback (RLAIF)**, which has emerged as a scalable alternative to human-annotated RLHF. The second pillar, safety, moves beyond functional quality to address alignment, security, and potential misuse. This requires an evaluator agent that acts not as a "coach" but as a "red teamer," actively trying to find and flag unsafe behaviors using frameworks like OpenAgentSafety or Anthropic's Petri.
+
+### **The Decision Bill of Materials (DBOM): From Audit Log to Evidentiary Asset**
+
+The most profound governance contribution of the Orchestrator-Worker architecture is not its preventative capability, but the evidentiary artifact it produces as a native function of its operation. Because the system's "thinking" is an externalized communication process, it natively generates a complete and verifiable audit trail.
+
+This "structured thread log" is more than a debugging tool; it is the technical implementation of a critical, emerging governance concept: the **"Decision Bill of Materials (DBOM)"**. Analogous to a Software Bill of Materials (SBOM) which lists all software components, a DBOM is a "unified document" that "meticulously documents all elements contributing to a decision".
+
+> [*Legal Note:*] The creation of a verifiable DBOM bridges the gap between a technical architecture and an organization's legal and ethical obligations. This artifact is the primary mechanism by which AI developers can demonstrate compliance with new and emerging legal standards, such as the legal "duty of care" for the creators and deployers of AI systems. The DBOM, generated by the agentic-auditing architecture, is the specific, concrete, and verifiable evidence required to meet this legal burden.
+
+### **Systemic Risks in Multi-Agent Governance**
+
+This vision of automated, agentic governance is not a panacea. This new architecture effectively solves the "black box" problem of monolithic agents but, in doing so, creates a new and more complex set of systemic challenges. These new risks are not rooted in the opaquity of a single agent, but in the interactions between multiple agents. Key challenges include the **Principal-Agent Problem**, where a delegating "Orchestrator" agent cannot perfectly monitor its "Worker" agents, and the subsequent risk of **agent-to-agent collusion**, where a developer agent and an auditor agent might collude to approve malicious code.
+
+## **Conclusion: Navigating the Decade of Unknowable Code**
+
+This analysis has sought to define and explore the hypothesis that Contextual Debt—the future cost incurred from a lack of discernible human intent, architectural rationale, and domain-specific knowledge—is poised to become the single greatest source of software liability in the coming decade. The evidence suggests that this is not merely a new piece of jargon but a necessary term to describe a distinct and far more dangerous form of liability than traditional technical debt. While technical debt compromises a system's efficiency, Contextual Debt compromises its integrity, safety, and defensibility.
+
+The proliferation of generative AI in software development has acted as an inescapable catalyst, transforming what was once a chronic, manageable problem of knowledge loss into an acute crisis. AI's ability to generate vast quantities of functional but context-free code forces organizations to confront their own systemic amnesia with ruthless efficiency.21 The productivity gains offered by these tools are undeniable, but they come at the cost of "comprehension debt," creating systems that are maintained by developers who never built the foundational "theory" of how they work.
+
+This technical crisis is unfolding in parallel with a seismic shift in the legal and regulatory landscape. The era of software's immunity from liability is ending. Governments and regulatory bodies are moving decisively to establish a "duty of care" for software vendors, and the legal standard is coalescing around negligence. In this new world, the inability of an organization to explain the "why" behind its own critical systems will be indefensible. The presence of high Contextual Debt will be seen as clear evidence of a failure to exercise reasonable diligence.
+
+Therefore, senior leaders must move beyond viewing these issues as purely technical concerns to be delegated to the engineering department. The management of Contextual Debt must be elevated to a strategic priority, integrated into corporate risk management frameworks, and championed by the highest levels of leadership. The necessary mitigation strategies—adopting Architectural Decision Records, embracing Domain-Driven Design, and implementing robust governance for AI-generated code—are not just engineering best practices. They are essential acts of corporate governance and the proactive creation of the evidentiary artifacts required to navigate the future legal landscape.
+
+Our business model, the **"Consult-to-Product" Flywheel**, is designed to tackle this head-on. We are already signing high-margin consulting contracts to perform "archeological code digs." This *paid data acquisition* is building the world's only proprietary dataset of "intent failure," which serves as the unassailable data moat for our scalable SaaS platform.
+
+This is not a developer tool. This is a new category of enterprise risk management. We are building the mandatory, auditable standard for "Contextual Integrity"—the "Fair Isaac" for all software.
+
+#### **Works cited**
+
+1. What is Technical Debt? Definition, History, and Strategy | Praxent, accessed October 26, 2025, [https://praxent.com/blog/brief-history-technical-debt](https://praxent.com/blog/brief-history-technical-debt)
+2. Introduction to the Technical Debt Concept | Agile Alliance, accessed October 26, 2025, [https://www.agilealliance.org/wp-content/uploads/2016/05/IntroductiontotheTechnicalDebtConcept-V-02.pdf](https://www.agilealliance.org/wp-content/uploads/2016/05/IntroductiontotheTechnicalDebtConcept-V-02.pdf)
+3. medium.com, accessed October 26, 2025, [https://medium.com/@yvan.callaou/our-systems-have-no-memory-i-call-it-contextual-debt-d656af68d80b\#:\~:text=Contextual%20Debt%20is%20the%20accumulated,%E2%80%9D%20behind%20the%20%E2%80%9Cwhat.%E2%80%9D](https://medium.com/@yvan.callaou/our-systems-have-no-memory-i-call-it-contextual-debt-d656af68d80b#:~:text=Contextual%20Debt%20is%20the%20accumulated,%E2%80%9D%20behind%20the%20%E2%80%9Cwhat.%E2%80%9D)
+4. Why AI-Generated Code Hurts Your Exit – The Bootstrapped Founder, accessed October 26, 2025, [https://thebootstrappedfounder.com/why-ai-generated-code-hurts-your-exit/](https://thebootstrappedfounder.com/why-ai-generated-code-hurts-your-exit/)
+5. Tracing the Footsteps of Technical Debt in Microservices: A Preliminary Case Study \- Roberto Verdecchia, accessed October 26, 2025, [https://robertoverdecchia.github.io/papers/QUALIFIER\_2023.pdf](https://robertoverdecchia.github.io/papers/QUALIFIER_2023.pdf)
+6. Technical Debt in Microservices: A Mixed-Method Case Study \- Roberto Verdecchia, accessed October 26, 2025, [https://robertoverdecchia.github.io/papers/QUALIFIER\_2024.pdf](https://robertoverdecchia.github.io/papers/QUALIFIER_2024.pdf)
+7. The Future of Software Liability: How Software Vendors Can ..., accessed October 26, 2025, [https://www.veritas.com/blogs/the-future-of-software-liability-how-software-vendors-can-prepare-for-increasing-responsibility](https://www.veritas.com/blogs/the-future-of-software-liability-how-software-vendors-can-prepare-for-increasing-responsibility)
+8. Bugs in the Software Liability Debate \- Just Security, accessed October 26, 2025, [https://www.justsecurity.org/87294/bugs-in-the-software-liability-debate/](https://www.justsecurity.org/87294/bugs-in-the-software-liability-debate/)
+9. What Is Technical Debt? | Definition and Examples \- ProductPlan, accessed October 26, 2025, [https://www.productplan.com/glossary/technical-debt/](https://www.productplan.com/glossary/technical-debt/)
+10. If you want to address tech debt, quantify it first \- Stack Overflow, accessed October 26, 2025, [https://stackoverflow.blog/2023/08/24/if-you-want-to-address-tech-debt-quantify-it-first/](https://stackoverflow.blog/2023/08/24/if-you-want-to-address-tech-debt-quantify-it-first/)
+11. Technical debt \- Wikipedia, accessed October 26, 2025, [https://en.wikipedia.org/wiki/Technical\_debt](https://en.wikipedia.org/wiki/Technical_debt)
+12. What is Technical Debt? | IBM, accessed October 26, 2025, [https://www.ibm.com/think/topics/technical-debt](https://www.ibm.com/think/topics/technical-debt)
+13. tagged by: technical debt \- Martin Fowler, accessed October 26, 2025, [https://martinfowler.com/tags/technical%20debt.html](https://martinfowler.com/tags/technical%20debt.html)
+14. Technical Debt Quadrant \- Martin Fowler, accessed October 26, 2025, [https://martinfowler.com/bliki/TechnicalDebtQuadrant.html](https://martinfowler.com/bliki/TechnicalDebtQuadrant.html)
+15. Technical Debt: Definition \+ Management | monday.com Blog, accessed October 26, 2025, [https://monday.com/blog/rnd/technical-debt/](https://monday.com/blog/rnd/technical-debt/)
+16. Technical Debt Explained \- Codacy | Blog, accessed October 26, 2025, [https://blog.codacy.com/technical-debt](https://blog.codacy.com/technical-debt)
+17. From Technical Debt to Design Integrity | by Alberto Brandolini \- Medium, accessed October 26, 2025, [https://medium.com/@ziobrando/from-technical-debt-to-design-integrity-48e7056b6776](https://medium.com/@ziobrando/from-technical-debt-to-design-integrity-48e7056b6776)
+18. Technical Debt is over-used : r/PHP \- Reddit, accessed October 26, 2025, [https://www.reddit.com/r/PHP/comments/1hgxmap/technical\_debt\_is\_overused/](https://www.reddit.com/r/PHP/comments/1hgxmap/technical_debt_is_overused/)
+19. What is Technical Debt? Causes, Types & Definition Guide \- Sonar, accessed October 26, 2025, [https://www.sonarsource.com/resources/library/technical-debt/](https://www.sonarsource.com/resources/library/technical-debt/)
+20. How to Tackle Technical Debt and Maintain High Software Quality \- Qt, accessed October 26, 2025, [https://www.qt.io/quality-assurance/blog/how-to-tackle-technical-debt](https://www.qt.io/quality-assurance/blog/how-to-tackle-technical-debt)
+21. Our Systems Have No Memory. I Call It Contextual Debt | by Yvan Callaou \- Medium, accessed October 26, 2025, [https://medium.com/@yvan.callaou/our-systems-have-no-memory-i-call-it-contextual-debt-d656af68d80b](https://medium.com/@yvan.callaou/our-systems-have-no-memory-i-call-it-contextual-debt-d656af68d80b)
+22. Understanding Technical Debt. Technical debt, a concept ..., accessed October 26, 2025, [https://jatinmishra27.medium.com/understanding-technical-debt-6fe846fde3a8](https://jatinmishra27.medium.com/understanding-technical-debt-6fe846fde3a8)
+23. Your AI Assistant is a Genius with Amnesia: How to Onboard It | by Krzyś | Generative AI, accessed October 26, 2025, [https://generativeai.pub/why-your-ai-assistant-writes-idiotic-code-and-how-to-fix-it-4512b2b5ceb5](https://generativeai.pub/why-your-ai-assistant-writes-idiotic-code-and-how-to-fix-it-4512b2b5ceb5)
+24. Mastering Domain-Driven Design: A Strategic Framework for ..., accessed October 26, 2025, [https://medium.com/@Kirtiswagat/the-automation-garage-domain-driven-design-architecture-for-the-financial-industry-c524cf757e14](https://medium.com/@Kirtiswagat/the-automation-garage-domain-driven-design-architecture-for-the-financial-industry-c524cf757e14)
+25. Examples of Technical Debt's Cybersecurity Impact \- DTIC, accessed October 26, 2025, [https://apps.dtic.mil/sti/trecms/pdf/AD1144728.pdf](https://apps.dtic.mil/sti/trecms/pdf/AD1144728.pdf)
+26. Impact of technical debt: how to identify and reduce it \- Paddle, accessed October 26, 2025, [https://www.paddle.com/resources/technical-debt](https://www.paddle.com/resources/technical-debt)
+27. How AI-Generated Code is messing with your Technical Debt \- Kodus, accessed October 26, 2025, [https://kodus.io/en/ai-generated-code-is-messing-with-your-technical-debt/](https://kodus.io/en/ai-generated-code-is-messing-with-your-technical-debt/)
+28. The Hidden Costs of Coding With Generative AI \- MIT Sloan Management Review, accessed October 26, 2025, [https://sloanreview.mit.edu/article/the-hidden-costs-of-coding-with-generative-ai/](https://sloanreview.mit.edu/article/the-hidden-costs-of-coding-with-generative-ai/)
+29. Technical Debt and AI: Understanding the Tradeoff and How to Stay Ahead \- Qodo, accessed October 26, 2025, [https://www.qodo.ai/blog/technical-debt/](https://www.qodo.ai/blog/technical-debt/)
+30. Why AI-generated code is creating a technical debt nightmare | Okoone, accessed October 26, 2025, [https://www.okoone.com/spark/technology-innovation/why-ai-generated-code-is-creating-a-technical-debt-nightmare/](https://www.okoone.com/spark/technology-innovation/why-ai-generated-code-is-creating-a-technical-debt-nightmare/)
+31. A Case Study on Technical Debt in a Large-Scale Industrial Microservice Architecture \- arXiv, accessed October 26, 2025, [https://arxiv.org/html/2506.16214v1](https://arxiv.org/html/2506.16214v1)
+32. Microservices as Technical Debt: A Critical Perspective | by Dhruv ..., accessed October 26, 2025, [https://medium.com/c-sharp-programming/microservices-as-technical-debt-a-critical-perspective-77e8ab9a1a92](https://medium.com/c-sharp-programming/microservices-as-technical-debt-a-critical-perspective-77e8ab9a1a92)
+33. (PDF) Architectural Technical Debt in Microservices: A Case Study in a Large Company, accessed October 26, 2025, [https://www.researchgate.net/publication/331904375\_Architectural\_Technical\_Debt\_in\_Microservices\_A\_Case\_Study\_in\_a\_Large\_Company](https://www.researchgate.net/publication/331904375_Architectural_Technical_Debt_in_Microservices_A_Case_Study_in_a_Large_Company)
+34. What is Software Scalability and Why is it Important? \- CyberlinkASP, accessed October 26, 2025, [https://cyberlinkasp.com/what-is-software-scalability-and-why-is-it-important/](https://cyberlinkasp.com/what-is-software-scalability-and-why-is-it-important/)
+35. Preventing and Reducing Technical Debt at Railsware, accessed October 26, 2025, [https://railsware.com/blog/reduce-technical-debt/](https://railsware.com/blog/reduce-technical-debt/)
+36. Can some explain to me why scalability can be a huge issue in ..., accessed October 26, 2025, [https://www.reddit.com/r/learnprogramming/comments/1k2zxz/can\_some\_explain\_to\_me\_why\_scalability\_can\_be\_a/](https://www.reddit.com/r/learnprogramming/comments/1k2zxz/can_some_explain_to_me_why_scalability_can_be_a/)
+37. Impact of Technical Debt in Software Development | by TopDevelopers.co \- Medium, accessed October 26, 2025, [https://medium.com/@topdevelopers-co/impact-of-technical-debt-in-software-development-af6d0c6c051d](https://medium.com/@topdevelopers-co/impact-of-technical-debt-in-software-development-af6d0c6c051d)
+38. Managing the Consequences of Technical Debt: 5 Stories from the Field, accessed October 26, 2025, [https://www.sei.cmu.edu/blog/managing-the-consequences-of-technical-debt-5-stories-from-the-field/](https://www.sei.cmu.edu/blog/managing-the-consequences-of-technical-debt-5-stories-from-the-field/)
+39. Technical Debt Management: The Road Ahead for Successful Software Delivery \- arXiv, accessed October 26, 2025, [https://arxiv.org/html/2403.06484v1](https://arxiv.org/html/2403.06484v1)
+40. Understanding Software Liability: Implications for Businesses, accessed October 26, 2025, [https://technologybrokers.com.au/the-struggle-for-software-liability-why-it-matters-and-whats-next-for-businesses/](https://technologybrokers.com.au/the-struggle-for-software-liability-why-it-matters-and-whats-next-for-businesses/)
+41. The struggle for software liability: Inside a 'very, very, very hard problem', accessed October 26, 2025, [https://therecord.media/cybersecurity-software-liability-standards-white-house-struggle](https://therecord.media/cybersecurity-software-liability-standards-white-house-struggle)
+42. Three Questions on Software Liability | Lawfare, accessed October 26, 2025, [https://www.lawfaremedia.org/article/three-questions-on-software-liability](https://www.lawfaremedia.org/article/three-questions-on-software-liability)
+43. ADR process \- AWS Prescriptive Guidance \- AWS Documentation, accessed October 26, 2025, [https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html](https://docs.aws.amazon.com/prescriptive-guidance/latest/architectural-decision-records/adr-process.html)
+44. Architectural Decision Records, accessed October 26, 2025, [https://adr.github.io/](https://adr.github.io/)
+45. Architecture decision record (ADR) examples for software planning, IT leadership, and template documentation \- GitHub, accessed October 26, 2025, [https://github.com/joelparkerhenderson/architecture-decision-record](https://github.com/joelparkerhenderson/architecture-decision-record)
+46. Architecture decision record \- Microsoft Azure Well-Architected Framework, accessed October 26, 2025, [https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record](https://learn.microsoft.com/en-us/azure/well-architected/architect-role/architecture-decision-record)
+47. Documenting Architectural Decisions With ADRs A Practical Guide \- Growing Scrum Masters, accessed October 26, 2025, [https://www.growingscrummasters.com/keywords/architecture-decision-records/](https://www.growingscrummasters.com/keywords/architecture-decision-records/)
+48. Understanding Domain-Driven Design: A Practical Approach for ..., accessed October 26, 2025, [https://sensiolabs.com/blog/2024/understanding-domain-driven-design](https://sensiolabs.com/blog/2024/understanding-domain-driven-design)
+49. Domain-Driven Design Demystified \- NDepend Blog, accessed October 26, 2025, [https://blog.ndepend.com/domain-driven-design-demystified/](https://blog.ndepend.com/domain-driven-design-demystified/)
+50. 10 Things to Avoid in Domain-Driven Design (DDD) \- DZone, accessed October 26, 2025, [https://dzone.com/articles/10-things-to-avoid-in-domain-driven-design](https://dzone.com/articles/10-things-to-avoid-in-domain-driven-design)
+51. Artificial Intelligence and Technical Debt: Navigating the New Frontier \- CAST Software, accessed October 26, 2025, [https://www.castsoftware.com/pulse/artificial-intelligence-and-technical-debt-navigating-the-new-frontier](https://www.castsoftware.com/pulse/artificial-intelligence-and-technical-debt-navigating-the-new-frontier)

--- a/docs/strategy_and_ip/Copyright_Registration_Playbook.md
+++ b/docs/strategy_and_ip/Copyright_Registration_Playbook.md
@@ -25,7 +25,12 @@ This document provides a step-by-step guide for preparing and registering the co
     *   **Rationale:** This transforms the paper from a purely academic work into a foundational document for the business. It establishes a clear link between the core problem ("Contextual Debt") and the commercial solution.
     *   **Source:** `docs/strategy_and_ip/03_INVESTOR_PITCH.md`
 
-*   **[ ] 4. Final Review and "Completion":**
+*   **[ ] 4. Conduct Deep Research Session (Optional but Recommended):**
+    *   Use a large language model (e.g., Google Gemini) to conduct a comparative analysis of the consolidated master document.
+    *   **Objective:** Compare the paper's structure, tone, and depth against other seminal, copyrighted works that have achieved significant commercial or academic success (e.g., whitepapers that launched major open-source projects, foundational academic papers that created new fields).
+    *   **Rationale:** This step serves as a final quality control and strategic refinement check. It can uncover potential weaknesses or opportunities to strengthen the paper before it is finalized for registration, increasing its long-term strategic value.
+
+*   **[ ] 5. Final Review and "Completion":**
     *   Perform a final read-through to ensure the integrated document is coherent and complete.
     *   **Guidance:** As per the legal advice, "complete" does not mean "final forever." It means the work is a finished, identifiable whole in its current state, ready for deposit.
 


### PR DESCRIPTION
This commit executes Phase 1 of the copyright registration strategy.

- Creates the new `Copyright-Edition-Contextual-Debt-Paper.md` by consolidating the research paper, core IP definitions, and the investor pitch into a single, comprehensive document.
- Updates the `Copyright_Registration_Playbook.md` to include a new, optional step for conducting a deep research session with an LLM for comparative analysis.

- read `docs/strategy_and_ip/Copyright_Registration_Playbook.md` for more info