### PR TITLE
feat: Create strategic recommendation report

### DIFF
--- a/logs/technical/20251119-Recommendation-Report-Strategic-Path-Forward.md
+++ b/logs/technical/20251119-Recommendation-Report-Strategic-Path-Forward.md
@@ -1,0 +1,45 @@
+# Recommendation Report: Strategic Path Forward (2025-11-19)
+
+## 1. Executive Summary
+
+**Recommendation:** The most intelligent and direct path forward is to **first finalize the core technical formalizations of the "Contextual Integrity Score" (CIS) within the research paper revision documents.**
+
+This is not a choice between "documentation" and "product development." The analysis shows that the mathematical and architectural specifications being developed in the paper revisions *are the technical blueprint* for the Strategic Pivot. Finalizing this blueprint is the necessary first step to de-risk the pivot, ensure team alignment, and accelerate the creation of a tangible, defensible product. Attempting to create a detailed pivot plan without this finalized specification would be premature and would introduce significant ambiguity and rework.
+
+## 2. Analysis of Strategic Options
+
+Based on the project's documentation, two distinct paths were considered:
+
+*   **Option A: The "Blueprint-First" Path.** Dedicate the next work cycle to completing the in-progress revisions to the research paper (`20251118-Copyright-Edition-Contextual-Debt-Paper.md`), specifically focusing on the new sections that provide a mathematically rigorous definition of the CIS protocol.
+*   **Option B: The "Plan-First" Path.** Immediately begin drafting a new, detailed `Strategic-Pivot-Plan` based on the *current, draft-level* ideas in the research paper and its associated critiques.
+
+## 3. Evaluation Against Stated Priorities
+
+The decision was evaluated against the established project priorities: 1) Tangible Product, 2) Team Alignment, 3) IP Strengthening.
+
+### Priority 1: Tangible Product Path
+
+The "Plan-First" path (Option B) appears, superficially, to be the most direct route to a product. However, this is deceptive. The `Gap-Analysis` reveals that the pivot is a fundamental technical replacement, moving from a qualitative rubric to a quantitative, mathematically-driven system.
+
+Crucially, the **precise formulas and architectural protocols for this new system do not yet exist in a finalized state.** They are actively being defined in the proposed revisions (`20251118-proposed-Section-2.2.md`, `20251119-proposed-Section-2.3.md`).
+
+Therefore, choosing the "Blueprint-First" path (Option A) is the most effective way to accelerate the tangible product. By formalizing the CIS function and the "Agent-as-a-Judge" architecture first, we create a clear, unambiguous technical specification. This allows the subsequent implementation plan to be concrete, actionable, and stable, directly serving the goal of building a robust product.
+
+### Priority 2: Team Alignment
+
+The `Red-Team-Analysis` provides a high-confidence prediction that the incoming team of experts will unanimously endorse the Strategic Pivot. Their collective expertise is in data science, process control, formal verification, and reliable systems.
+
+This team will expect and value a development process that is grounded in rigor. Presenting them with a detailed implementation plan that is based on an incomplete and qualitative technical specification would be a poor start. By contrast, presenting them with a mathematically-defensible protocol (from the revised paper) and then collaboratively building the implementation plan will maximize their buy-in and leverage their specific skills most effectively. The "Blueprint-First" approach is in perfect alignment with their predicted professional values.
+
+### Priority 3: IP Strengthening
+
+The "Blueprint-First" path (Option A) directly and immediately strengthens the project's core intellectual property. The act of formalizing the CIS as a mathematical formula and defining the "Decision Bill of Materials" (DBOM) transforms the concept from a "thought leadership" piece into a defensible technical protocol, which is a far stronger foundation for a copyright claim and future patents.
+
+## 4. Conclusion and Justification
+
+The decision is clear. The project is at an inflection point where the very definition of the product is being upgraded. The logic for this upgrade is being forged in the research paper revisions.
+
+*   **To create the pivot plan now** would be to build on sand. The plan would be filled with ambiguities that could only be resolved by finishing the work on the paper's technical sections.
+*   **To finish the paper's core revisions first** is to build on rock. It provides a stable, mathematically-sound foundation for the subsequent implementation plan and the product itself.
+
+The most intelligent decision is to **proceed with Option A**. We must complete the formalization of the CIS and the "Agent-as-a-Judge" architecture as the immediate next step. This action simultaneously satisfies all three strategic priorities in the correct order of dependency: it secures the **IP** by defining it, enables **Team Alignment** by providing a rigorous foundation, and creates the fastest, most direct path to a **Tangible Product** by providing a clear blueprint for its construction.


### PR DESCRIPTION
logs/technical/20251119-Recommendation-Report-Strategic-Path-Forward.md This commit adds a new report that analyzes the project's strategic options and provides a recommendation for the next steps. The report is based on an analysis of the existing project documentation and aligns with the stated project priorities.