### PR TITLE
docs: Update Strategic-Master-Log with inflection point

### DIFF
--- a/logs/20251118-Strategic-Master-Log.md
+++ b/logs/20251118-Strategic-Master-Log.md
@@ -1,4 +1,15 @@
-# Strategic Master Log (2025-11-18)
+# Strategic Master Log (2025-11-19)
+
+## **CURRENT STATUS (2025-11-19): Strategic Inflection Point**
+
+**Attention New Team Members:** You are joining the project at a critical and exciting moment. We have just completed an analysis that has resulted in a major strategic decision.
+
+The project is currently at a strategic inflection point, moving from a prototype-based technical plan to a more rigorous, mathematically-defined approach for our core IP. The tension between our old `RECOVERY_PLAN` and a proposed `Strategic-Pivot-Plan` has now been resolved.
+
+**Your first action is to read the following report:**
+*   **`logs/technical/20251119-Recommendation-Report-Strategic-Path-Forward.md`**: This document provides the official analysis and justification for our immediate path forward. It is the definitive source of truth for the project's current priorities.
+
+The flowchart and document descriptions below provide essential historical context, but the recommendation report above is your guide for what we are doing *right now*.
 
 ## A Guide for Humans and AI Agents
 
@@ -10,6 +21,8 @@ Our goal is to maintain a "living document" that bridges the gap between human u
 
 ## Documentation Flowchart: A "Choose Your Own Adventure"
 
+> **Note:** The diagram below shows the key documents that led to our current strategic decision. The most important node for you to focus on now is the **Recommendation Report**, which resolves the conflict between the two main technical plans.
+
 This diagram provides a high-level map of the project's documentation. Start with the `PROJECT_PLAN.md` to understand the overall vision, then explore the different paths based on your area of interest.
 
 ```mermaid
@@ -18,13 +31,17 @@ graph TD
         A("PROJECT_PLAN.md <br> [The high-level vision, team roles, and target architecture. Your starting point.]")
     end
 
-    subgraph "The Workshop: Current Technical Plan & Status"
-        B("logs/technical/20251113_RECOVERY_PLAN.md <br> [The detailed, tactical work plan the team is currently executing.]")
+    subgraph "The Workshop: The Old Plan (Now Deprecated)"
+        B("logs/technical/20251113_RECOVERY_PLAN.md <br> [**DEPRECATED:** The previous work plan. Valuable for historical context only.]")
         C("logs/CoPilot/20251117-Task-1.2-Completion-Summary.md <br> [The most recent status update showing progress against the Recovery Plan.]")
     end
 
+    subgraph "The Decision Point: Read This Now"
+        I("logs/technical/20251119-Recommendation-Report-Strategic-Path-Forward.md <br> [**CURRENT PRIORITY:** This report analyzes the two competing plans and defines our immediate path forward. **START HERE.**]")
+    end
+
     subgraph "The Cutting Edge: Strategic Pivots & IP Development"
-        D("docs/strategy_and_ip/20251118-Copyright-Edition-Contextual-Debt-Paper.md <br> [The foundational research paper defining our core IP, 'Contextual Debt'.]")
+        D("docs/strategy_and_ip/20251118-Copyright-Edition-Contextual-Debt-Paper.md <br> [The foundational research paper defining our core IP, 'Contextual Debt'. This is being actively revised.]")
         E("docs/strategy_and_ip/DOC-REVISIONS/20251118-Strategic Critique_ 'The Unknowable Code' vs. Seminal Technical Literature.md <br> [A critical review of the paper that inspired a major strategic pivot.]")
         F("logs/ip_and_business/20251118-Strategic-Pivot-Plan-CIS-Formalization.md <br> [**EXPERIMENTAL PLAN:** Proposes a new, mathematically rigorous approach to our core metrics. Ambitious and NOT yet integrated into the main recovery plan.]")
     end
@@ -45,18 +62,23 @@ graph TD
     B --> C;
     D -- inspires --> E;
     E -- leads to --> F;
-    F -.->|Proposes to replace<br>Workstream 1 in| B;
+    B -- was in conflict with --> F;
+    F -- resolved by --> I;
+    B -- resolved by --> I;
+    I -- defines next steps for --> D;
 
     %% Styling
     classDef start fill:#D5F5E3,stroke:#2ECC71,stroke-width:2px;
     classDef workshop fill:#EBF5FB,stroke:#3498DB,stroke-width:2px;
-    classDef cuttingEdge fill:#FDEDEC,stroke:#E74C3C,stroke-width:2px;
+    classDef cuttingEdge fill:#FEF9E7,stroke:#F1C40F,stroke-width:2px;
     classDef genesis fill:#FEF9E7,stroke:#F1C40F,stroke-width:2px;
     classDef quickstart fill:#E8DAEF,stroke:#8E44AD,stroke-width:2px;
+    classDef decision fill:#FDEDEC,stroke:#E74C3C,stroke-width:4px,stroke-dasharray: 5 5;
 
 
     class A start;
     class B,C workshop;
+    class I decision;
     class D,E,F cuttingEdge;
     class G genesis;
     class H quickstart;
@@ -72,11 +94,11 @@ This section provides the high-level context for the entire project. If you are 
 
 ---
 
-## 2. The Workshop: Current Technical Plan & Status
+## 2. The Workshop: Historical Technical Plan
 
-This section details the current, day-to-day engineering work. This is the "how"—the specific tasks the development team is actively working on.
+This section details the engineering work that was being performed *prior* to our current strategic pivot. These documents are now primarily for historical context.
 
-*   **`logs/technical/20251113_RECOVERY_PLAN.md`**: This is the project's tactical source of truth. It translates the high-level goals from the `PROJECT_PLAN.md` into concrete, actionable engineering workstreams. It is the most important document for understanding what the team is building *right now*.
+*   **`logs/technical/20251113_RECOVERY_PLAN.md`**: **(DEPRECATED)** This was the project's previous tactical source of truth. It is preserved here to provide context for the decisions made in the `Recommendation-Report`. It should not be used as a guide for current work.
 
 *   **`logs/CoPilot/20251117-Task-1.2-Completion-Summary.md`**: This is the most recent changelog or status report for the codebase. It documents the completion of a specific task from the `RECOVERY_PLAN.md`, providing a snapshot of our recent progress and technical decisions.
 
@@ -84,7 +106,7 @@ This section details the current, day-to-day engineering work. This is the "how"
 
 ## 3. The Cutting Edge: Strategic Pivots & IP Development
 
-This section contains the project's most ambitious and forward-looking ideas. The documents here define our core intellectual property and explore a potential major evolution of our technical strategy. **Note:** The ideas here are influential but have not yet been formally merged into the main development plan.
+This section contains the project's most ambitious and forward-looking ideas. The documents here define our core intellectual property and explore the major evolution of our technical strategy that we are now formally adopting.
 
 *   **`docs/strategy_and_ip/20251118-Copyright-Edition-Contextual-Debt-Paper.md`**: This is the foundational document for our entire project. It defines the concept of "Contextual Debt," which is our core intellectual property and the central problem we aim to solve. The latest version has been updated to prepare it for a formal copyright application.
 


### PR DESCRIPTION
Updates the Strategic-Master-Log to make the current strategic direction clear for new team members.

- Adds a "CURRENT STATUS" section at the top, directing readers to the new recommendation report.
- Modifies the Mermaid diagram to visually represent the strategic pivot, marking the old plan as deprecated.
- Updates section descriptions to reflect the new project state.