### PR TITLE
docs: Revise Contextual Discovery Plan

### DIFF
--- a/20251124-Contextual-Discovery-Plan.md
+++ b/20251124-Contextual-Discovery-Plan.md
@@ -1,12 +1,21 @@
 # 20251124-Contextual-Discovery-Plan (Revised)
 
-## 1. Objective: The Discovery Sprint
+## 1. Referenced Documents
 
-This document outlines a one-week "Discovery Sprint" to validate the core hypotheses of the `20251118-Strategic-Pivot-Plan`. Our goal is **not to implement features**, but to reduce risk by answering critical open questions across two domains: **Technical Feasibility** (Tracks 1-4) and **Competition Alignment** (Track 5).
+This plan synthesizes and extends the strategic direction outlined in the following core documents. It is recommended to review them for full context:
+
+- **The New Pivot:** `logs/ip_and_business/20251118-Strategic-Pivot-Plan-CIS-Formalization.md`
+- **The Old Plan:** `logs/technical/20251113_RECOVERY_PLAN.md`
+- **The Conflict Analysis:** `logs/technical/20251118-Gap-Analysis-Recovery-vs-Pivot.md`
+- **Competition Strategy:** `docs/20251102-AgentX AgentBeats Competition Analysis.md`
+
+## 2. Objective: The Discovery Sprint
+
+This document outlines a one-week "Discovery Sprint" to validate the core hypotheses of the `logs/ip_and_business/20251118-Strategic-Pivot-Plan-CIS-Formalization.md`. Our goal is **not to implement features**, but to reduce risk by answering critical open questions across two domains: **Technical Feasibility** (Tracks 1-4) and **Competition Alignment** (Track 5).
 
 Success for this sprint is defined as **Risk Reduction via Falsification**. We will produce a set of "Decision Records"—memos, proofs-of-concept, and formal audits—that give us the confidence to proceed, or the evidence needed to pivot again safely.
 
-## 2. Discovery Track 1: The "Derivative Trap" (Validation of Rationale Integrity)
+## 3. Discovery Track 1: The "Derivative Trap" (Validation of Rationale Integrity)
 
 **Context:** The pivot proposes using Vector Embeddings and Cosine Similarity to measure the alignment between intent and code.
 **The Core Question:** Is our approach genuinely novel from both a product and mathematical standpoint?
@@ -26,7 +35,7 @@ Success for this sprint is defined as **Risk Reduction via Falsification**. We w
     *   **Task:** Produce a formal mathematical proof demonstrating that our proposed CIS formulas are distinct from standard cosine similarity and other common RAG/QA metrics.
     *   **Deliverable:** A formal proof document (e.g., LaTeX PDF or markdown with embedded equations).
 
-## 3. Discovery Track 2: The "Vaporware" Risk (Validation of Security Architecture)
+## 4. Discovery Track 2: The "Vaporware" Risk (Validation of Security Architecture)
 
 **Context:** The strategic paper promises a cryptographic "Decision Bill of Materials" (DBOM). We will use a "spec-first" approach to validate this.
 **The Core Question:** Can we formally specify and then successfully implement a forensically useful, signed artifact for a code change?
@@ -41,7 +50,7 @@ Success for this sprint is defined as **Risk Reduction via Falsification**. We w
     *   **Task:** Build a proof-of-concept that implements Hadiza's DBOM schema, proving a library like Auth0 or `jose` can generate a verifiable signature for an artifact that strictly adheres to the schema.
     *   **Deliverable:** A "Crypto Implementation Report" with a working script that ingests the DBOM schema, validates a sample payload, and successfully generates/verifies a signature.
 
-## 4. Discovery Track 3: The "Math Gap" (Bridging Team Knowledge)
+## 5. Discovery Track 3: The "Math Gap" (Bridging Team Knowledge)
 
 **Context:** The pivot introduces advanced mathematical concepts that are not yet common knowledge within the team.
 **The Core Question:** Are the formulas in the paper correct and computable, and can we translate them into practical algorithms?
@@ -56,7 +65,7 @@ Success for this sprint is defined as **Risk Reduction via Falsification**. We w
     *   **Task:** Translate the abstract mathematical formulas for the CIS into concrete pseudocode or a simple Python script with numerical examples.
     *   **Deliverable:** A markdown document or notebook that a non-expert can read to understand how the math would be implemented.
 
-## 5. Discovery Track 4: Documentation Graphing (The Meta-Layer)
+## 6. Discovery Track 4: Documentation Graphing (The Meta-Layer)
 
 **Context:** We aim to treat our documentation repository as a mission-critical, auditable system of record.
 **The Core Question:** Can we model our documentation workflow as an event-driven system to ensure its integrity and traceability?
@@ -71,14 +80,21 @@ Success for this sprint is defined as **Risk Reduction via Falsification**. We w
     *   **Task:** Define a clear data model for the documentation graph itself, which would be the consumer of the events defined by Aron.
     *   **Deliverable:** A JSON schema or TypeScript interface definition that represents the target data structure of the graph.
 
-## 6. Discovery Track 5: Competition & Go-to-Market Alignment
+*   **Experiment 4.3: The Data Accessibility & Link Extraction POC**
+    *   **Assignee:** Team Lead (Josh).
+    *   **Task:** This experiment has two parts:
+        1.  **Accessibility Test:** Verify that the Node.js server in `onboarding/` can be configured to safely read file contents from the root `docs/` and `logs/` directories to prove the data connection is possible.
+        2.  **Link Extraction Spike:** Write a script (e.g., Python or Node.js) that can traverse the `docs/` and `logs/` directories and extract all explicit markdown links (`[text](./path/to/file.md)`) to build a preliminary adjacency list of the documentation graph. This validates the core mechanism needed to combat "reference rot."
+    *   **Deliverable:** A brief report summarizing the findings. It should include a "Pass/Fail" for the accessibility test and the proof-of-concept script for link extraction.
+
+## 7. Discovery Track 5: Competition & Go-to-Market Alignment
 
 **Context:** A technically sound solution that is misaligned with the competition's evaluation framework is a strategic failure. This track validates our narrative and technical integration strategy.
 **The Core Question:** How do we frame our CIS technology and integrate it within the AgentBeats SDK to create a winning submission?
 
 *   **Experiment 5.1: The "Winning Narrative" Blueprint**
     *   **Assignee:** The TPM (Deepti).
-    *   **Task:** Synthesize the `Competition Analysis` document with our CIS concept to produce a "Narrative & Strategy Memo." This document must explicitly articulate the end-to-end story for the judges, connecting our "Green Agent" (CIS as a benchmark) and our "Purple Agent" (an agent that excels on it) to the sponsor's goals (especially Auth0's security focus).
+    *   **Task:** Synthesize the `docs/20251102-AgentX AgentBeats Competition Analysis.md` document with our CIS concept to produce a "Narrative & Strategy Memo." This document must explicitly articulate the end-to-end story for the judges, connecting our "Green Agent" (CIS as a benchmark) and our "Purple Agent" (an agent that excels on it) to the sponsor's goals (especially Auth0's security focus).
     *   **Deliverable:** A 2-page memo outlining the proposed narrative, the key talking points for the pitch, and how our project embodies the "powerful *and* trustworthy" archetype.
 
 *   **Experiment 5.2: The SDK & Auth0 Integration Spike**
@@ -86,7 +102,7 @@ Success for this sprint is defined as **Risk Reduction via Falsification**. We w
     *   **Task:** Conduct a technical spike to answer critical integration questions. Decompile the AgentBeats SDK if necessary. The primary goal is to create a POC demonstrating how a Purple Agent, running within the SDK, can use Auth0's Token Vault and FGA to interact with a sandboxed resource.
     *   **Deliverable:** A working code sample and a brief report answering: What are the SDK's architectural constraints? How can an agent securely access and manage secrets (e.g., Auth0 tokens) within the SDK? What is the most compelling way to demonstrate Auth0's value in a live demo?
 
-## 7. Knowledge Gaps
+## 8. Knowledge Gaps
 
 *This section is intentionally blank. Please add any new questions or uncertainties that arise during the Discovery Sprint.*
 

--- a/logs/technical/josh-temp/20251123-working-log.md
+++ b/logs/technical/josh-temp/20251123-working-log.md
@@ -22,6 +22,9 @@ The core idea is to visualize the contextual relationships between all documents
 - **SUPERSEDED:** The results of this analysis should be viewable in the `onboarding/` website.
 - **NEW (2025-11-23):** The new foundational step is to connect the log summary to the existing simple web server and graph implementation in the `onboarding/` folder. The logic of connecting nodes is the priority; the UI is secondary and should be simple (e.g., click a node to open the document in a new tab).
 
+> [!NOTE] Contradiction with Discovery Plan
+> This task jumps directly to implementation. The authoritative `../../../20251124-Contextual-Discovery-Plan.md` prioritizes a "Hypothesis & Discovery" approach. Per Experiment 4.3 in that plan, the immediate goal is only to validate data accessibility and link extraction, not to implement any UI or connection logic.
+
 ## 3. Core Problem: Documentation Management & Unanswered Questions
 
 ### 3.1. Documentation Organization


### PR DESCRIPTION
Revises the 20251124-Contextual-Discovery-Plan.md to improve clarity and accuracy.

- Adds a "Referenced Documents" section with full relative paths to provide better context.
- Integrates a new task from the team lead's working log to validate documentation accessibility and link extraction.
- Corrects a broken relative link in the working log and adds a note to resolve a contradiction with the discovery plan's "Anti-Solutionism" philosophy.