### PR TITLE
Audit H100 session, reorganize documentation, and update agent protocols

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,12 @@
 
 ## Core Rule
 
-**Before completing any task, update documentation to maintain system integrity.** The single source of truth is `docs/00_CURRENT_TRUTH_SOURCE.md`—if your work affects the roadmap, specs, or deprecates anything, update it there. All new docs in `docs/` must use the header template (`docs/TEMPLATE_DOC.md`) with Status tags (ACTIVE, DRAFT, SNAPSHOT, DEPRECATED, SUPERSEDED) and Type tags (Plan, Spec, Log, Minutes, Research, Guide).
+**Before completing any task, update documentation to maintain system integrity.** The single source of truth is `docs/00_CURRENT_TRUTH_SOURCE.md`—if your work affects the roadmap, specs, or deprecates anything, update it there.
+
+For detailed instructions on managing documentation (creating files, folder structure, RST integration), strictly follow:
+**`docs/Docs-Management-Instruction-Manual.md`**
+
+All new docs in `docs/` must use the header template (`docs/TEMPLATE_DOC.md`) with Status tags (ACTIVE, DRAFT, SNAPSHOT, DEPRECATED, SUPERSEDED) and Type tags (Plan, Spec, Log, Minutes, Research, Guide).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,12 @@
 
 ## Core Rule
 
-**Before completing any task, update documentation to maintain system integrity.** The single source of truth is `docs/00_CURRENT_TRUTH_SOURCE.md`—if your work affects the roadmap, specs, or deprecates anything, update it there. All new docs in `docs/` must use the header template (`docs/TEMPLATE_DOC.md`) with Status tags (ACTIVE, DRAFT, SNAPSHOT, DEPRECATED, SUPERSEDED) and Type tags (Plan, Spec, Log, Minutes, Research, Guide).
+**Before completing any task, update documentation to maintain system integrity.** The single source of truth is `docs/00_CURRENT_TRUTH_SOURCE.md`—if your work affects the roadmap, specs, or deprecates anything, update it there.
+
+For detailed instructions on managing documentation (creating files, folder structure, RST integration), strictly follow:
+**`docs/Docs-Management-Instruction-Manual.md`**
+
+All new docs in `docs/` must use the header template (`docs/TEMPLATE_DOC.md`) with Status tags (ACTIVE, DRAFT, SNAPSHOT, DEPRECATED, SUPERSEDED) and Type tags (Plan, Spec, Log, Minutes, Research, Guide).
 
 ---
 


### PR DESCRIPTION
- Generated QA Audit Report for H100 session (`docs/04-Operations/Intent-Log/Josh/20260103-Session-Audit-Report.md`)
- Restructured `docs/04-Operations` by creating `Dual-Track-Arena` folder and consolidating agent documentation
- Created `docs/04-Operations/Intent-Log/Josh/20260103-Hybrid-Architecture-Cost-Saving-Plan.md`
- Moved `Docs-Management-Instruction-Manual.md` to `docs/` root
- Updated `AGENTS.md` and `CLAUDE.md` to reference the instruction manual
- Updated `docs/index.rst` and nested indices for Sphinx navigation