### PR TITLE
feat: replace mock LLM client with OpenAiLlmClient in Rationale Worker

### DIFF
--- a/docs/04-Operations/Dual-Track-Arena/green-agent/Rationale_Worker_Configuration.md
+++ b/docs/04-Operations/Dual-Track-Arena/green-agent/Rationale_Worker_Configuration.md
@@ -1,0 +1,61 @@
+# Rationale Worker Configuration
+
+This document explains how to configure the Rationale Worker to use an LLM provider (like OpenAI or a local vLLM instance) for analyzing "Rationale Debt".
+
+## Overview
+
+The `rationale-worker` is a background process that consumes analysis tasks from the `rationale-analysis` queue. It uses a Large Language Model (LLM) to evaluate the reasoning steps of an AI agent and detect potential flaws or "debt".
+
+Previously, this worker used a mock client. It has now been upgraded to use a real HTTP-based LLM client (`OpenAiLlmClient`).
+
+## Configuration
+
+The worker is configured via environment variables.
+
+| Variable | Description | Default | Example (vLLM) |
+| :--- | :--- | :--- | :--- |
+| `LLM_API_BASE_URL` | The base URL of the LLM API. | `https://api.openai.com/v1` | `http://localhost:8000/v1` |
+| `LLM_API_KEY` | The API key for authentication. | `""` (Empty string) | `EMPTY` (for local vLLM) |
+| `LLM_MODEL_NAME` | The name of the model to use. | `gpt-4o` | `Qwen/Qwen2.5-Coder-32B-Instruct-AWQ` |
+
+## Connection Examples
+
+### 1. Connecting to Local vLLM (Competition Standard)
+
+This is the standard configuration for the AgentX competition, running a local model on the GPU instance.
+
+```bash
+export LLM_API_BASE_URL="http://localhost:8000/v1"
+export LLM_API_KEY="EMPTY"
+export LLM_MODEL_NAME="Qwen/Qwen2.5-Coder-32B-Instruct-AWQ"
+
+# Start the worker
+pnpm start:rationale
+```
+
+### 2. Connecting to OpenAI
+
+Useful for development or testing if you don't have a local GPU.
+
+```bash
+export LLM_API_BASE_URL="https://api.openai.com/v1"
+export LLM_API_KEY="sk-..."
+export LLM_MODEL_NAME="gpt-4o"
+
+# Start the worker
+pnpm start:rationale
+```
+
+## How it Works
+
+1.  The `rationale-worker` initializes the `OpenAiLlmClient` using the environment variables.
+2.  When a job is received, it constructs a prompt containing the agent's goal, consumed context, and rationale.
+3.  It sends this prompt to the configured LLM API.
+4.  The LLM evaluates the rationale and returns a JSON object indicating if debt was incurred.
+5.  The worker parses this response and returns a `RationaleDebtReport`.
+
+## Troubleshooting
+
+*   **Connection Refused:** Ensure your vLLM server is running and accessible at the `LLM_API_BASE_URL`.
+*   **401 Unauthorized:** Check your `LLM_API_KEY`. For local vLLM, use "EMPTY".
+*   **Model Not Found:** Ensure `LLM_MODEL_NAME` matches the model loaded in vLLM (check vLLM logs).

--- a/packages/workers/src/analyzers.ts
+++ b/packages/workers/src/analyzers.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as os from 'os';
 
 // A simplified interface for a local LLM client (e.g., Ollama)
-interface LlmClient {
+export interface LlmClient {
   prompt(systemMessage: string, userMessage: string): Promise<string>;
 }
 

--- a/packages/workers/src/clients/OpenAiLlmClient.test.ts
+++ b/packages/workers/src/clients/OpenAiLlmClient.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenAiLlmClient } from './OpenAiLlmClient';
+
+describe('OpenAiLlmClient', () => {
+  const baseUrl = 'https://api.openai.com/v1';
+  const apiKey = 'test-api-key';
+  const modelName = 'gpt-4o';
+  let client: OpenAiLlmClient;
+
+  beforeEach(() => {
+    client = new OpenAiLlmClient(baseUrl, apiKey, modelName);
+    // Mock global fetch
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should successfully call the API and return content', async () => {
+    const mockResponse = {
+      choices: [
+        {
+          message: {
+            content: 'Test response content',
+          },
+        },
+      ],
+    };
+
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    const result = await client.prompt('System prompt', 'User prompt');
+
+    expect(result).toBe('Test response content');
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseUrl}/chat/completions`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: modelName,
+          messages: [
+            { role: 'system', content: 'System prompt' },
+            { role: 'user', content: 'User prompt' },
+          ],
+          temperature: 0.0,
+        }),
+      }),
+    );
+  });
+
+  it('should throw an error if the API response is not ok', async () => {
+    (global.fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+
+    await expect(client.prompt('System', 'User')).rejects.toThrow(
+      'LLM API request failed with status 500: Internal Server Error',
+    );
+  });
+
+  it('should throw an error if the response content is missing', async () => {
+    const mockResponse = {
+      choices: [], // Empty choices
+    };
+
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    });
+
+    await expect(client.prompt('System', 'User')).rejects.toThrow(
+      'LLM API response missing content',
+    );
+  });
+});

--- a/packages/workers/src/clients/OpenAiLlmClient.ts
+++ b/packages/workers/src/clients/OpenAiLlmClient.ts
@@ -1,0 +1,57 @@
+import { LlmClient } from '../analyzers';
+
+export class OpenAiLlmClient implements LlmClient {
+  private baseUrl: string;
+  private apiKey: string;
+  private modelName: string;
+
+  constructor(baseUrl: string, apiKey: string, modelName: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, ''); // Remove trailing slashes
+    this.apiKey = apiKey;
+    this.modelName = modelName;
+  }
+
+  async prompt(systemMessage: string, userMessage: string): Promise<string> {
+    const url = `${this.baseUrl}/chat/completions`;
+    const headers = {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${this.apiKey}`,
+    };
+
+    const body = JSON.stringify({
+      model: this.modelName,
+      messages: [
+        { role: 'system', content: systemMessage },
+        { role: 'user', content: userMessage },
+      ],
+      temperature: 0.0, // Deterministic output for consistent analysis
+    });
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `LLM API request failed with status ${response.status}: ${errorText}`,
+        );
+      }
+
+      const data = await response.json();
+      const content = data.choices?.[0]?.message?.content;
+
+      if (!content) {
+        throw new Error('LLM API response missing content');
+      }
+
+      return content;
+    } catch (error) {
+      console.error('LlmClient prompt failed:', error);
+      throw error;
+    }
+  }
+}

--- a/packages/workers/src/rationale-worker.ts
+++ b/packages/workers/src/rationale-worker.ts
@@ -1,14 +1,21 @@
 import { Worker } from 'bullmq';
 import { getRedisConnection } from '@logomesh/core';
 import { RationaleDebtAnalyzer } from './analyzers';
+import { OpenAiLlmClient } from './clients/OpenAiLlmClient';
 
-// TODO: The RationaleDebtAnalyzer needs a real LlmClient.
-const mockLlmClient = {
-  prompt: async () =>
-    '{ "debtIncurred": true, "incurredByContextId": "mockId", "debtScore": 0.5, "details": "mocked" }',
-};
+const llmBaseUrl = process.env.LLM_API_BASE_URL || 'https://api.openai.com/v1';
+const llmApiKey = process.env.LLM_API_KEY || '';
+const llmModelName = process.env.LLM_MODEL_NAME || 'gpt-4o';
 
-const rationaleAnalyzer = new RationaleDebtAnalyzer(mockLlmClient);
+if (!llmApiKey && llmBaseUrl.includes('openai.com')) {
+  console.warn('Warning: LLM_API_KEY is not set, but using OpenAI URL.');
+}
+
+console.log(`[Rationale Worker] Using LLM Provider: ${llmBaseUrl}`);
+console.log(`[Rationale Worker] Using Model: ${llmModelName}`);
+
+const llmClient = new OpenAiLlmClient(llmBaseUrl, llmApiKey, llmModelName);
+const rationaleAnalyzer = new RationaleDebtAnalyzer(llmClient);
 
 const startWorker = async () => {
   console.log('[Rationale Worker] Initializing...');


### PR DESCRIPTION
- Implemented `OpenAiLlmClient` in `packages/workers/src/clients/OpenAiLlmClient.ts` to support OpenAI and vLLM APIs.
- Updated `packages/workers/src/rationale-worker.ts` to use `OpenAiLlmClient` with configuration from environment variables (`LLM_API_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL_NAME`).
- Exported `LlmClient` interface in `packages/workers/src/analyzers.ts`.
- Added unit tests for `OpenAiLlmClient` in `packages/workers/src/clients/OpenAiLlmClient.test.ts`.
- Added configuration documentation in `docs/04-Operations/Dual-Track-Arena/green-agent/Rationale_Worker_Configuration.md`.