### PR TITLE
docs: update setup guides to include Rationale Worker

### DIFF
--- a/docs/04-Operations/Intent-Log/Josh/20260101-Lambda-Noob-Guide-MacOS.md
+++ b/docs/04-Operations/Intent-Log/Josh/20260101-Lambda-Noob-Guide-MacOS.md
@@ -144,7 +144,16 @@ sudo docker run -d --name green-agent --network host \
   polyglot-agent:latest \
   uv run python main.py --role GREEN --port 9000
 
-# 3. Launch Purple Agent (The Defender) - Port 9001
+# 3. Launch Rationale Worker (Contextual Debt Analysis)
+# Analyzes reasoning traces using vLLM
+sudo docker run -d --name rationale-worker --network host \
+  -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+  -e LLM_API_KEY=EMPTY \
+  -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+  polyglot-agent:latest \
+  pnpm start:rationale
+
+# 4. Launch Purple Agent (The Defender) - Port 9001
 sudo docker run -d --name purple-agent --network host \
   -e OPENAI_BASE_URL=http://localhost:8000/v1 \
   -e OPENAI_API_KEY=EMPTY \

--- a/docs/04-Operations/Intent-Log/Josh/20260101-Lambda-Noob-Guide.md
+++ b/docs/04-Operations/Intent-Log/Josh/20260101-Lambda-Noob-Guide.md
@@ -144,7 +144,16 @@ sudo docker run -d --name green-agent --network host \
   polyglot-agent:latest \
   uv run python main.py --role GREEN --port 9000
 
-# 3. Launch Purple Agent (The Defender) - Port 9001
+# 3. Launch Rationale Worker (Contextual Debt Analysis)
+# Analyzes reasoning traces using vLLM
+sudo docker run -d --name rationale-worker --network host \
+  -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+  -e LLM_API_KEY=EMPTY \
+  -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+  polyglot-agent:latest \
+  pnpm start:rationale
+
+# 4. Launch Purple Agent (The Defender) - Port 9001
 sudo docker run -d --name purple-agent --network host \
   -e OPENAI_BASE_URL=http://localhost:8000/v1 \
   -e OPENAI_API_KEY=EMPTY \

--- a/docs/04-Operations/Intent-Log/Josh/20260101-Lambda-Test-Protocol.md
+++ b/docs/04-Operations/Intent-Log/Josh/20260101-Lambda-Test-Protocol.md
@@ -68,7 +68,17 @@ Before renting the instance, ensure the Docker image is ready.
       --port 8000
     ```
 
-3.  **Run the Purple Agent (Client/Test Subject):**
+3.  **Run the Rationale Worker:**
+    ```bash
+    docker run -d --name rationale-worker --network host \
+      -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+      -e LLM_API_KEY=EMPTY \
+      -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+      polyglot-agent:latest \
+      pnpm start:rationale
+    ```
+
+4.  **Run the Purple Agent (Client/Test Subject):**
     *   Open a second SSH terminal.
     *   Run the Purple Agent to connect to the Green Agent:
     ```bash

--- a/docs/04-Operations/Intent-Log/Josh/20260103-Instance-Restart-Guide.md
+++ b/docs/04-Operations/Intent-Log/Josh/20260103-Instance-Restart-Guide.md
@@ -63,6 +63,15 @@ sudo docker run -d --name green-agent --network host \
   polyglot-agent:latest \
   uv run python main.py --role GREEN --port 9000
 
+# 6. Launch Rationale Worker
+sudo docker run -d --name rationale-worker --network host \
+  -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+  -e LLM_API_KEY=EMPTY \
+  -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+  polyglot-agent:latest \
+  pnpm start:rationale
+
+# 7. Launch Purple Agent
 sudo docker run -d --name purple-agent --network host \
   -e OPENAI_BASE_URL=http://localhost:8000/v1 \
   -e OPENAI_API_KEY=EMPTY \

--- a/docs/04-Operations/Intent-Log/Samuel/20260101-Lambda-Test-Protocol.md
+++ b/docs/04-Operations/Intent-Log/Samuel/20260101-Lambda-Test-Protocol.md
@@ -68,7 +68,17 @@ Before renting the instance, ensure the Docker image is ready.
       --port 8000
     ```
 
-3.  **Run the Purple Agent (Client/Test Subject):**
+3.  **Run the Rationale Worker:**
+    ```bash
+    docker run -d --name rationale-worker --network host \
+      -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+      -e LLM_API_KEY=EMPTY \
+      -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+      polyglot-agent:latest \
+      pnpm start:rationale
+    ```
+
+4.  **Run the Purple Agent (Client/Test Subject):**
     *   Open a second SSH terminal.
     *   Run the Purple Agent to connect to the Green Agent:
     ```bash

--- a/docs/04-Operations/Intent-Log/Samuel/20260103-Instance-Restart-Guide.md
+++ b/docs/04-Operations/Intent-Log/Samuel/20260103-Instance-Restart-Guide.md
@@ -63,6 +63,15 @@ sudo docker run -d --name green-agent --network host \
   polyglot-agent:latest \
   uv run python main.py --role GREEN --port 9000
 
+# 6. Launch Rationale Worker
+sudo docker run -d --name rationale-worker --network host \
+  -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+  -e LLM_API_KEY=EMPTY \
+  -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+  polyglot-agent:latest \
+  pnpm start:rationale
+
+# 7. Launch Purple Agent
 sudo docker run -d --name purple-agent --network host \
   -e OPENAI_BASE_URL=http://localhost:8000/v1 \
   -e OPENAI_API_KEY=EMPTY \

--- a/docs/04-Operations/Intent-Log/Samuel/20260103-Lambda-Cloud-Setup-Guide-MacOS.md
+++ b/docs/04-Operations/Intent-Log/Samuel/20260103-Lambda-Cloud-Setup-Guide-MacOS.md
@@ -142,7 +142,16 @@ sudo docker run -d --name green-agent --network host \
   polyglot-agent:latest \
   uv run python main.py --role GREEN --port 9000
 
-# 3. Launch Purple Agent (The Defender) - Port 9001
+# 3. Launch Rationale Worker (Contextual Debt Analysis)
+# Analyzes reasoning traces using vLLM
+sudo docker run -d --name rationale-worker --network host \
+  -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+  -e LLM_API_KEY=EMPTY \
+  -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+  polyglot-agent:latest \
+  pnpm start:rationale
+
+# 4. Launch Purple Agent (The Defender) - Port 9001
 sudo docker run -d --name purple-agent --network host \
   -e OPENAI_BASE_URL=http://localhost:8000/v1 \
   -e OPENAI_API_KEY=EMPTY \

--- a/docs/04-Operations/Intent-Log/Samuel/20260103-Lambda-Cloud-Setup-Guide-Windows.md
+++ b/docs/04-Operations/Intent-Log/Samuel/20260103-Lambda-Cloud-Setup-Guide-Windows.md
@@ -142,7 +142,16 @@ sudo docker run -d --name green-agent --network host \
   polyglot-agent:latest \
   uv run python main.py --role GREEN --port 9000
 
-# 3. Launch Purple Agent (The Defender) - Port 9001
+# 3. Launch Rationale Worker (Contextual Debt Analysis)
+# Analyzes reasoning traces using vLLM
+sudo docker run -d --name rationale-worker --network host \
+  -e LLM_API_BASE_URL=http://localhost:8000/v1 \
+  -e LLM_API_KEY=EMPTY \
+  -e LLM_MODEL_NAME=Qwen/Qwen2.5-Coder-32B-Instruct \
+  polyglot-agent:latest \
+  pnpm start:rationale
+
+# 4. Launch Purple Agent (The Defender) - Port 9001
 sudo docker run -d --name purple-agent --network host \
   -e OPENAI_BASE_URL=http://localhost:8000/v1 \
   -e OPENAI_API_KEY=EMPTY \


### PR DESCRIPTION
- Updated `Lambda-Noob-Guide.md` (Windows/MacOS) to include the `rationale-worker` docker run command.
- Updated `Lambda-Cloud-Setup-Guide` (Windows/MacOS) with the same instructions.
- Updated `Instance-Restart-Guide.md` for both Josh and Samuel with the `rationale-worker` restoration step.
- Updated `Lambda-Test-Protocol.md` to include the `rationale-worker` in the deployment checklist.
- Added environment variable configuration (`LLM_API_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL_NAME`) to all guides for vLLM integration.