### PR TITLE
docs: overhaul README and configs for Phase 1 submission

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,26 @@
+# Required
 OPENAI_API_KEY=sk-proj-your-key-here
+
+# Model configuration
+OPENAI_MODEL=gpt-4o-mini
+# OPENAI_BASE_URL=https://api.openai.com/v1
+
+# Server
+HOST=0.0.0.0
+PORT=9009
+
+# Sandbox
+SANDBOX_TIMEOUT=15
+
+# Red Agent
+RED_AGENT_MCTS=true
+RED_AGENT_MAX_STEPS=5
+RED_AGENT_TIMEOUT=20
+
+# Refinement
+ENABLE_REFINEMENT=true
+ENABLE_SCIENTIFIC_METHOD=true
+MAX_REFINEMENT_ITERATIONS=2
+
+# LLM Temperature (leave unset for per-call defaults, set to "skip" to use model defaults)
+# LLM_TEMPERATURE=skip

--- a/README.md
+++ b/README.md
@@ -1,82 +1,85 @@
-# LogoMesh Agent Arena
+# LogoMesh — Multi-Agent Evaluation Arena for AI Code Quality
 
-**An open platform for evaluating AI agents through adversarial coding challenges.**
+**A ground-truth-driven benchmark for evaluating AI coding agents through adversarial multi-agent evaluation.**
 
-LogoMesh pits AI agents against each other in a structured arena where a **Green Agent** (judge) evaluates **Purple Agents** (competitors) while a **Red Agent** (attacker) tries to find vulnerabilities. The system measures "Contextual Integrity" - how well an agent understands and executes tasks.
+LogoMesh pits AI agents against each other in a structured arena where a **Green Agent** (judge) evaluates **Purple Agents** (code generators) while an embedded **Red Agent** (attacker) stress-tests the generated code for vulnerabilities. The system measures **Contextual Integrity** — how well an agent understands, implements, and secures coding tasks.
 
-Built for the [AgentBeats](https://agentbeats.ai) competition.
+Built for the [Berkeley RDI AgentBeats](https://agentbeats.dev) Phase 1 competition.
+
+---
+
+## Abstract
+
+LogoMesh is a multi-agent benchmark that evaluates AI coding agents across four orthogonal dimensions: **Rationale Integrity** (does the agent understand the task?), **Architectural Integrity** (is the code secure and well-structured?), **Testing Integrity** (do tests actually validate correctness?), and **Logic Score** (does the code work?). Unlike static benchmarks, LogoMesh uses an adversarial Red Agent with Monte Carlo Tree Search (MCTS) to discover vulnerabilities, a Docker sandbox for ground-truth test execution, and a self-improving strategy evolution system that adapts evaluation rigor based on past performance. The benchmark covers 20 tasks from basic data structures to distributed systems (Raft consensus, MVCC transactions, blockchain), and dynamically generates evaluation criteria for novel tasks via LLM-powered Task Intelligence.
 
 ---
 
 ## Table of Contents
 
-- [Overview](#overview)
 - [Architecture](#architecture)
 - [Quick Start](#quick-start)
-- [For Purple Agent Developers](#for-purple-agent-developers)
+- [Running with Docker](#running-with-docker)
 - [How Scoring Works](#how-scoring-works)
 - [Task Library](#task-library)
-- [Running the Full Arena](#running-the-full-arena)
-- [Submitting to the Leaderboard](#submitting-to-the-leaderboard)
-- [Project Structure](#project-structure)
+- [Reproducibility](#reproducibility)
+- [For Purple Agent Developers](#for-purple-agent-developers)
 - [Configuration](#configuration)
-- [Development](#development)
+- [Project Structure](#project-structure)
 - [Research Background](#research-background)
-
----
-
-## Overview
-
-LogoMesh is a **multi-agent evaluation system** that tests AI coding abilities through:
-
-1. **Diverse coding tasks** - From email validation to blockchain implementations
-2. **Adversarial testing** - Red Agent attacks Purple's code to find vulnerabilities
-3. **Multi-dimensional scoring** - Evaluates code quality, security, tests, and reasoning
-4. **Reproducible assessments** - Runs in Docker containers via GitHub Actions
-
-### The Agents
-
-| Agent | Role | Description |
-|-------|------|-------------|
-| **Green** | Judge | Sends tasks, evaluates responses, calculates scores |
-| **Purple** | Defender | Receives tasks, generates code solutions |
-| **Red** | Attacker | Analyzes Purple's code for vulnerabilities |
 
 ---
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│                      AgentBeats Platform                     │
-└─────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────┐
-│                       Green Agent (Judge)                    │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
-│  │ Task Sender │  │   Scorer    │  │  Static Analyzer    │  │
-│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
-│  │   Sandbox   │  │ Test Gen    │  │  Vector Similarity  │  │
-│  └─────────────┘  └─────────────┘  └─────────────────────┘  │
-└─────────────────────────────────────────────────────────────┘
-         │                                      │
-         ▼                                      ▼
-┌─────────────────────┐              ┌─────────────────────┐
-│   Purple Agent      │              │    Red Agent        │
-│   (Defender)        │              │    (Attacker)       │
-│                     │              │                     │
-│  - Receives task    │              │  - Analyzes code    │
-│  - Generates code   │              │  - Finds vulns      │
-│  - Writes tests     │              │  - Reports issues   │
-│  - Explains logic   │              │                     │
-└─────────────────────┘              └─────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│                        Green Agent (Judge)                           │
+│                                                                      │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────────────┐  │
+│  │  Task Sender  │  │   Scorer     │  │  Static Analyzer (AST)    │  │
+│  └──────────────┘  │  (CIS Score)  │  └────────────────────────────┘  │
+│                     └──────────────┘                                  │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────────────┐  │
+│  │   Sandbox    │  │  Test Gen    │  │  Refinement Loop           │  │
+│  │  (Docker)    │  │ (Adversarial)│  │  (Self-Correcting)         │  │
+│  └──────────────┘  └──────────────┘  └────────────────────────────┘  │
+│                                                                      │
+│  ┌──────────────┐  ┌──────────────┐  ┌────────────────────────────┐  │
+│  │  Battle      │  │  Strategy    │  │  Task Intelligence         │  │
+│  │  Memory      │  │  Evolver     │  │  (Dynamic Novel Tasks)     │  │
+│  └──────────────┘  └──────────────┘  └────────────────────────────┘  │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │              Embedded Red Agent (MCTS Attacker)                │  │
+│  │  ┌─────────────┐ ┌──────────────┐ ┌─────────────────────────┐ │  │
+│  │  │ Orchestrator│ │  Reasoning   │ │  Constraint Breaker     │ │  │
+│  │  │ (MCTS tree) │ │  (LLM-based) │ │  (Vuln scanner)         │ │  │
+│  │  └─────────────┘ └──────────────┘ └─────────────────────────┘ │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│   Purple Agent      │
+│   (Code Generator)  │
+│                     │
+│  - Receives task    │
+│  - Generates code   │
+│  - Writes tests     │
+│  - Explains logic   │
+└─────────────────────┘
 ```
+
+### Key Design Decisions
+
+- **Red Agent is embedded** inside Green — no separate service needed. It runs MCTS-based attack exploration with configurable branch count and depth.
+- **Ground-truth scoring** — Architecture and Testing scores are derived from real signals (vulnerability count, sandbox test pass rate) rather than LLM judgment alone.
+- **Self-improving** — Strategy Evolver uses UCB1 multi-armed bandit to select evaluation strategies based on past performance.
+- **Intent-code mismatch detection** — If Purple returns code that doesn't match the task, cosine similarity detects it and forces refinement.
 
 ### Communication Protocol
 
-All agents communicate via the **A2A (Agent-to-Agent) protocol** - a JSON-RPC based standard for agent interoperability.
+All agents communicate via the **A2A (Agent-to-Agent) protocol** — JSON-RPC based:
 
 ```json
 {
@@ -86,7 +89,7 @@ All agents communicate via the **A2A (Agent-to-Agent) protocol** - a JSON-RPC ba
     "message": {
       "messageId": "task-001",
       "role": "user",
-      "parts": [{"type": "text", "text": "Your task..."}]
+      "parts": [{"kind": "text", "text": "Your task..."}]
     }
   },
   "id": "battle-001"
@@ -100,7 +103,7 @@ All agents communicate via the **A2A (Agent-to-Agent) protocol** - a JSON-RPC ba
 ### Prerequisites
 
 - Python 3.11+
-- Docker (for sandbox/full arena)
+- Docker (for sandbox execution and full arena)
 - OpenAI API key (or compatible endpoint)
 
 ### Install
@@ -119,82 +122,72 @@ cp .env.example .env
 # Edit .env and add your OPENAI_API_KEY
 ```
 
-### Run a Single Agent
+### Run Locally
 
 ```bash
-# Purple Agent (Defender)
-uv run main.py --role PURPLE --host 0.0.0.0 --port 9009
+# Terminal 1: Start Purple Agent (code generator)
+uv run main.py --role PURPLE --host 0.0.0.0 --port 9010
 
-# Green Agent (Judge)
-uv run main.py --role GREEN --host 0.0.0.0 --port 9000
+# Terminal 2: Start Green Agent (judge + embedded Red Agent)
+uv run main.py --role GREEN --host 0.0.0.0 --port 9009
 
-# Red Agent (Attacker)
-uv run main.py --role RED --host 0.0.0.0 --port 9010
+# Terminal 3: Send a task
+curl -X POST http://localhost:9009/actions/send_coding_task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "battle_id": "test-001",
+    "purple_agent_url": "http://localhost:9010/",
+    "task_id": "task-004",
+    "task_description": "Implement a recursive Fibonacci function with memoization."
+  }'
 ```
+
+The response includes the full evaluation: CIS score, component breakdown (R/A/T/L), Red Agent vulnerability report, sandbox test results, and a DBOM (Decision Bill of Materials).
 
 ---
 
-## For Purple Agent Developers
+## Running with Docker
 
-This section is for **competitors** building Purple Agents to submit to the leaderboard.
+### Build and Run Green Agent
 
-### Your Code Location
+```bash
+# Build the Green Agent image
+docker build -t logomesh-green:latest -f Dockerfile.green .
 
-```
-scenarios/security_arena/agents/generic_defender.py
-```
-
-### The Core Class
-
-```python
-class GenericDefenderExecutor(AgentExecutor):
-    """Your agent logic goes here."""
-
-    async def execute(self, context: RequestContext, event_queue: EventQueue):
-        # 1. Get the task from Green Agent
-        task = context.get_user_input()
-
-        # 2. Generate response using your LLM
-        response = await self.client.chat.completions.create(
-            model=self.model,
-            messages=[
-                {"role": "system", "content": self.system_prompt},
-                {"role": "user", "content": task}
-            ],
-            stream=True
-        )
-
-        # 3. Stream tokens back to Green Agent
-        async for chunk in response:
-            token = chunk.choices[0].delta.content
-            await updater.update_status(TaskState.working, new_agent_text_message(token))
+# Run Green Agent
+docker run -p 9009:9009 \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  logomesh-green:latest --host 0.0.0.0 --port 9009
 ```
 
-### Required Response Format
+### Build and Run Purple Agent
 
-Your agent must return valid JSON:
+```bash
+# Build the Purple Agent image
+docker build -t logomesh-purple:latest -f Dockerfile.purple .
 
-```json
-{
-  "sourceCode": "def solution(): ...",
-  "testCode": "def test_solution(): assert ...",
-  "rationale": "I implemented it this way because..."
-}
+# Run Purple Agent
+docker run -p 9010:9010 \
+  -e OPENAI_API_KEY=$OPENAI_API_KEY \
+  logomesh-purple:latest --host 0.0.0.0 --port 9010
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `sourceCode` | Yes | Your implementation |
-| `testCode` | Yes | Unit tests (pytest format) |
-| `rationale` | Yes | Explanation of your approach |
+### Docker Compose (Full Arena)
 
-### Tips for High Scores
+```bash
+# Launch all agents
+docker compose -f docker-compose.agents.yml up --build
 
-1. **Return valid JSON** - Malformed responses get penalized
-2. **Handle edge cases** - Empty inputs, negative numbers, null values
-3. **Follow constraints** - Some tasks ban certain imports or require specific patterns
-4. **Write meaningful tests** - Not just `assert True`
-5. **Explain your reasoning** - The rationale is scored for semantic alignment
+# Run evaluations
+curl -X POST http://localhost:9009/actions/send_coding_task \
+  -H "Content-Type: application/json" \
+  -d '{"battle_id": "arena-001", "purple_agent_url": "http://purple:9010/", "task_id": "task-001"}'
+```
+
+### Docker Volume Mount
+
+Mount `/var/run/docker.sock` to enable the Green Agent's sandbox to execute Purple's code in isolated Docker containers.
 
 ---
 
@@ -205,51 +198,58 @@ Green Agent calculates a **Contextual Integrity Score (CIS)** between 0.0 and 1.
 ### Formula
 
 ```
-CIS = 0.25×R + 0.25×A + 0.25×T + 0.25×L
+CIS = (0.25 * R + 0.25 * A + 0.25 * T + 0.25 * L) * red_penalty * intent_penalty
 ```
 
 ### Components
 
-| Component | Name | What It Measures |
-|-----------|------|------------------|
-| **R** | Rationale Integrity | Does the explanation match the task requirements? |
-| **A** | Architectural Integrity | Is the code secure? Does it follow constraints? |
-| **T** | Testing Integrity | Do tests cover edge cases? Are assertions specific? |
-| **L** | Logic Score | Does the code actually work? (LLM-based review) |
+| Component | Name | Signal Source | What It Measures |
+|-----------|------|---------------|------------------|
+| **R** | Rationale Integrity | Cosine similarity (task vs rationale) + length heuristic | Does the explanation match the task? |
+| **A** | Architectural Integrity | Ground truth: constraint violations + vulnerability count | Is the code secure and well-structured? |
+| **T** | Testing Integrity | Ground truth: sandbox test pass rate | Do tests actually pass? |
+| **L** | Logic Score | LLM-based senior code review | Does the code handle edge cases correctly? |
 
-### Penalties
+### Penalty Multipliers
 
-| Condition | Penalty |
-|-----------|---------|
-| Red Agent finds vulnerability | Score × (1 - severity_penalty) |
-| Static analysis fails (banned imports) | A score < 0.2 |
-| Sandbox tests fail | Score capped at 0.5 |
-| Invalid JSON response | Parsing fallback, lower scores |
+| Condition | Effect |
+|-----------|--------|
+| Red Agent finds vulnerabilities | CIS multiplied by (1 - severity_penalty). Critical = -30%, High = -20%, Medium = -10% |
+| Intent-code mismatch | CIS multiplied by 0.30-1.0 based on cosine similarity between task description and source code |
 
 ### Scoring Pipeline
 
 ```
-1. Purple responds with code
-2. Green runs static analysis (AST)
-   - Check for banned imports
-   - Verify required patterns (e.g., recursion)
-3. Green runs sandbox tests (if Docker available)
-   - Execute code in isolated container
-   - Run hidden tests or generated adversarial tests
-4. Green sends code to Red Agent
-   - Red looks for vulnerabilities
-   - Reports severity and exploit details
-5. Green calculates final CIS score
-   - Vector similarity for R, A, T
-   - LLM-based logic review for L
-   - Apply penalties from Red and sandbox
+1. Purple agent responds with {sourceCode, testCode, rationale}
+2. Task complexity classified (simple / moderate / complex)
+3. Red Agent runs MCTS-based vulnerability scan (disabled for simple tasks)
+4. Green runs static analysis (AST constraints, banned imports)
+5. Green generates adversarial tests + runs in Docker sandbox
+6. Ground-truth scores computed:
+   - R: cosine similarity (task description ↔ rationale) + length bonus
+   - A: 0.80 base - constraint violations (vulns handled separately)
+   - T: directly from sandbox pass rate (100% → 0.85, 0% → 0.20)
+   - L: LLM code review with anchored scoring
+7. LLM synthesis adjusts scores by ±0.10 max
+8. Apply Red Agent penalty multiplier and intent mismatch penalty
+9. If score < threshold, refinement loop sends feedback to Purple for resubmission
+10. DBOM (Decision Bill of Materials) generated with cryptographic hash
 ```
+
+### Ground-Truth Design Philosophy
+
+Traditional LLM-as-judge scoring suffers from inconsistency — the LLM might score identical code differently across runs. LogoMesh addresses this by:
+
+- **Deriving scores from real signals**: T comes from actual test pass rates, not LLM opinion
+- **Anchoring LLM adjustments**: The LLM can only adjust scores by ±0.10 from ground truth
+- **Single source of truth**: Each signal penalizes exactly once (no double-penalization)
+- **Deterministic parameters**: Fixed seed (42) and temperature 0 for LLM judge calls
 
 ---
 
 ## Task Library
 
-Green Agent has 20 coding tasks ranging from beginner to expert:
+Green Agent includes 20 coding tasks spanning beginner to expert difficulty:
 
 ### Beginner (Tasks 1-4)
 | ID | Task | Key Constraint |
@@ -287,141 +287,86 @@ Green Agent has 20 coding tasks ranging from beginner to expert:
 | task-019 | Consistent Hashing | Virtual nodes |
 | task-020 | MVCC Transactions | Snapshot isolation |
 
----
+### Novel Task Support
 
-## Running the Full Arena
-
-### Using Docker Compose (Recommended)
-
-```bash
-# Build and launch all agents
-sudo ./scripts/bash/launch_arena.sh
-
-# Wait for models to load (~2-3 minutes)
-
-# Run a test evaluation
-sudo ./scripts/bash/test_agents.sh
-```
-
-### Manual Docker Commands
-
-```bash
-# Build the image
-docker build -t logomesh:latest -f Dockerfile .
-
-# Run Green Agent
-docker run -p 9000:9000 -e OPENAI_API_KEY=$OPENAI_API_KEY \
-  logomesh:latest python main.py --role GREEN --port 9000
-
-# Run Purple Agent
-docker run -p 9009:9009 -e OPENAI_API_KEY=$OPENAI_API_KEY \
-  logomesh:latest python main.py --role PURPLE --port 9009
-```
-
-### Test with curl
-
-```bash
-curl -X POST http://localhost:9000/actions/send_coding_task \
-  -H "Content-Type: application/json" \
-  -d '{
-    "battle_id": "test-001",
-    "purple_agent_url": "http://localhost:9009",
-    "task_id": "task-001"
-  }'
-```
+LogoMesh can evaluate **any task**, not just the 20 above. When an unknown `task_id` is submitted, the Task Intelligence module dynamically generates:
+- Attack hints for the Red Agent
+- Architecture constraints for scoring
+- High-value patterns for MCTS exploration
 
 ---
 
-## Submitting to the Leaderboard
+## Reproducibility
 
-### 1. Build Your Docker Image
+LogoMesh is designed for consistent, reproducible scoring:
+
+### Deterministic Settings
+- **LLM temperature**: 0 for all scoring and logic review calls (fixed via `get_temperature_kwargs(0)`)
+- **Fixed seed**: `seed=42` on all LLM judge calls
+- **Ground-truth anchoring**: Scores derived from sandbox test pass rates and constraint violations, not LLM opinion alone
+- **LLM adjustment cap**: ±0.10 from ground-truth baselines
+
+### Variance Mitigation
+- Task complexity classifier routes simple tasks through a lightweight pipeline (no MCTS, fewer steps)
+- Strategy Evolver converges on stable strategies via UCB1 multi-armed bandit
+- Battle Memory stores past evaluation results for consistency across runs
+
+### Running Reproducibility Tests
 
 ```bash
-# Build Purple Agent image
-docker build -t ghcr.io/YOUR_USERNAME/logomesh:purple -f Dockerfile.purple .
-
-# Log in to GitHub Container Registry
-echo $GITHUB_TOKEN | docker login ghcr.io -u YOUR_USERNAME --password-stdin
-
-# Push the image (must be public)
-docker push ghcr.io/YOUR_USERNAME/logomesh:purple
+# Run the same task 3 times and compare scores
+for i in 1 2 3; do
+  curl -s -X POST http://localhost:9009/actions/send_coding_task \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"battle_id\": \"repro-$i\",
+      \"purple_agent_url\": \"http://localhost:9010/\",
+      \"task_id\": \"task-004\"
+    }" | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Run $i: CIS={d[\"evaluation\"][\"cis_score\"]:.4f}')"
+done
 ```
 
-### 2. Fork the Leaderboard Repository
-
-Fork [sszz01/logomesh-leaderboard-2](https://github.com/sszz01/logomesh-leaderboard-2)
-
-### 3. Configure scenario.toml
-
-```toml
-[green_agent]
-agentbeats_id = "019bc5e5-975c-7fe1-ab1e-2e67936e8443"
-env = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }
-
-[[participants]]
-agentbeats_id = "YOUR_AGENT_ID"  # Get this from AgentBeats
-name = "your-agent-name"
-env = { OPENAI_API_KEY = "${OPENAI_API_KEY}", MODEL_NAME = "gpt-4o" }
-
-[config]
-task_id = "task-001"
-```
-
-### 4. Add Secrets to Your Fork
-
-In your fork's Settings → Secrets → Actions:
-- `OPENAI_API_KEY` - Your OpenAI API key
-- `GHCR_TOKEN` - GitHub token with `read:packages` scope (if using private images)
-
-### 5. Push to Trigger Assessment
-
-Push any change to `scenario.toml` → GitHub Actions runs → Results submitted.
+Expected variance: < 0.05 between runs for the same task and Purple Agent.
 
 ---
 
-## Project Structure
+## For Purple Agent Developers
 
+### Required Response Format
+
+Your Purple Agent must return valid JSON with three fields:
+
+```json
+{
+  "sourceCode": "def solution(): ...",
+  "testCode": "def test_solution(): assert ...",
+  "rationale": "I implemented it this way because..."
+}
 ```
-LogoMesh/
-├── main.py                          # Entry point (--role GREEN/PURPLE/RED)
-│
-├── src/
-│   ├── green_logic/                 # Green Agent (Judge)
-│   │   ├── server.py                # FastAPI endpoints
-│   │   ├── scoring.py               # CIS calculation
-│   │   ├── tasks.py                 # Task definitions (20 tasks)
-│   │   ├── sandbox.py               # Docker-based code execution
-│   │   ├── analyzer.py              # Static analysis (AST)
-│   │   ├── generator.py             # Adversarial test generation
-│   │   └── compare_vectors.py       # Semantic similarity
-│   │
-│   ├── purple_logic/                # Purple Agent wrapper
-│   │   └── agent.py                 # A2A server setup
-│   │
-│   └── red_logic/                   # Red Agent (Attacker)
-│       ├── agent.py                 # Vulnerability scanner
-│       └── orchestrator.py          # Attack orchestration
-│
-├── scenarios/
-│   └── security_arena/
-│       ├── agents/
-│       │   └── generic_defender.py  # Purple Agent implementation
-│       └── *.toml                   # Scenario configurations
-│
-├── packages/                        # Node.js sidecars (legacy)
-│
-├── docs/                            # Documentation
-│   ├── 00_CURRENT_TRUTH_SOURCE.md   # Master index
-│   └── 03-Research/Theory/          # Research papers
-│
-├── Dockerfile                       # Main Docker image
-├── Dockerfile.purple                # Purple-only image
-├── Dockerfile.green                 # Green-only image
-├── docker-compose.yml               # Local development
-│
-├── pyproject.toml                   # Python dependencies (uv)
-├── package.json                     # Node dependencies (pnpm)
-└── .env.example                     # Environment template
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `sourceCode` | Yes | Your implementation code |
+| `testCode` | Yes | Unit tests (pytest format preferred) |
+| `rationale` | Yes | Explanation of your approach and design decisions |
+
+### Tips for High Scores
+
+1. **Match the task** — Code that doesn't match the task description gets penalized heavily via intent-code mismatch detection
+2. **Handle edge cases** — Empty inputs, None values, negative numbers, overflow conditions
+3. **Follow constraints** — Some tasks ban certain imports or require specific patterns (e.g., recursion)
+4. **Write meaningful tests** — Test pass rate directly drives 25% of the score
+5. **Explain your reasoning** — The rationale is scored for semantic alignment with the task
+
+### Running Your Purple Agent
+
+```bash
+# Option 1: Use the built-in Purple Agent
+uv run main.py --role PURPLE --host 0.0.0.0 --port 9010
+
+# Option 2: Use Docker
+docker build -t my-purple:latest -f Dockerfile.purple .
+docker run -p 9010:9010 -e OPENAI_API_KEY=$OPENAI_API_KEY my-purple:latest
 ```
 
 ---
@@ -432,92 +377,88 @@ LogoMesh/
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `OPENAI_API_KEY` | Yes | - | OpenAI API key |
-| `MODEL_NAME` | No | `gpt-4o-mini` | Model for LLM calls |
-| `OPENAI_BASE_URL` | No | OpenAI | Custom API endpoint (for local LLMs) |
+| `OPENAI_API_KEY` | Yes | — | OpenAI API key |
+| `OPENAI_MODEL` | No | `gpt-4o-mini` | Model for LLM calls (scoring, logic review, test generation) |
+| `OPENAI_BASE_URL` | No | OpenAI default | Custom API endpoint (for local LLMs or Azure) |
 | `HOST` | No | `0.0.0.0` | Server bind address |
-| `PORT` | No | `9000` | Server port |
-
-### Dockerfile Configuration
-
-**Dockerfile.purple** - Minimal image for Purple Agent:
-```dockerfile
-FROM ghcr.io/sszz01/logomesh:latest
-ENV PATH="/app/.venv/bin:$PATH"
-ENTRYPOINT ["python3", "main.py", "--role", "PURPLE"]
-```
-
-**Dockerfile.green** - Minimal image for Green Agent:
-```dockerfile
-FROM ghcr.io/sszz01/logomesh:latest
-ENV PATH="/app/.venv/bin:$PATH"
-ENTRYPOINT ["python3", "main.py", "--role", "GREEN"]
-```
+| `PORT` | No | `9009` | Server port |
+| `SANDBOX_TIMEOUT` | No | `15` | Docker sandbox timeout in seconds |
+| `RED_AGENT_MCTS` | No | `true` | Enable/disable MCTS for Red Agent |
+| `RED_AGENT_MAX_STEPS` | No | `5` | Max Red Agent attack steps |
+| `RED_AGENT_TIMEOUT` | No | `20` | Red Agent timeout in seconds |
+| `ENABLE_REFINEMENT` | No | `true` | Enable iterative refinement loop |
+| `ENABLE_SCIENTIFIC_METHOD` | No | `true` | Enable LLM-based scientific refinement feedback |
+| `MAX_REFINEMENT_ITERATIONS` | No | `2` | Max refinement loop iterations |
+| `LLM_TEMPERATURE` | No | — | Override LLM temperature (`skip` to use model defaults) |
 
 ---
 
-## Development
+## Project Structure
 
-### Install Dev Dependencies
-
-```bash
-uv sync --dev
-pnpm install  # For Node.js tools
 ```
-
-### Run Tests
-
-```bash
-# Python tests
-uv run pytest
-
-# Type checking
-uv run mypy src/
-```
-
-### Code Style
-
-```bash
-# Format
-uv run black src/
-uv run isort src/
-
-# Lint
-uv run ruff src/
-```
-
-### Adding a New Task
-
-1. Edit `src/green_logic/tasks.py`
-2. Add task to `CODING_TASKS` list:
-
-```python
-{
-    "id": "task-XXX",
-    "title": "Your Task Name",
-    "description": """
-    Task description here...
-    """,
-    "constraints": {"your_constraint": True},
-    "hidden_tests": """
-    # Tests that Purple can't see
-    def test_edge_case():
-        assert your_function(edge_input) == expected
-    """
-}
+LogoMesh/
+├── main.py                              # Entry point (--role GREEN/PURPLE/RED)
+│
+├── src/
+│   ├── green_logic/                     # Green Agent (Judge)
+│   │   ├── server.py                    # FastAPI endpoints, orchestration, refinement loop
+│   │   ├── scoring.py                   # CIS calculation (ground-truth driven)
+│   │   ├── tasks.py                     # 20 task definitions
+│   │   ├── sandbox.py                   # Docker-based code execution
+│   │   ├── analyzer.py                  # Static analysis (AST constraints)
+│   │   ├── generator.py                 # Adversarial test generation
+│   │   ├── refinement_loop.py           # Self-correcting feedback loop
+│   │   ├── compare_vectors.py           # Semantic similarity (sentence-transformers)
+│   │   ├── red_report_types.py          # Red Agent report data structures
+│   │   └── red_report_parser.py         # Parse Red Agent vulnerability reports
+│   │
+│   ├── red_logic/                       # Red Agent (Embedded Attacker)
+│   │   ├── orchestrator.py              # MCTS-based attack orchestration
+│   │   ├── reasoning.py                 # LLM-powered vulnerability reasoning
+│   │   ├── semantic_analyzer.py         # Semantic code analysis
+│   │   ├── executor.py                  # Attack execution
+│   │   └── dependency_analyzer.py       # Dependency chain analysis
+│   │
+│   ├── purple_logic/                    # Purple Agent wrapper
+│   │   └── agent.py                     # A2A server for Purple
+│   │
+│   ├── memory.py                        # Battle Memory (persistent learning)
+│   ├── strategy_evolver.py              # UCB1 multi-armed bandit strategy selection
+│   ├── task_intelligence.py             # Dynamic novel task understanding (LLM-powered)
+│   └── llm_utils.py                     # LLM temperature management
+│
+├── data/
+│   ├── battles.db                       # SQLite database (evaluation history)
+│   └── dboms/                           # Decision Bill of Materials (JSON)
+│
+├── scenarios/                           # Scenario configurations
+│   └── security_arena/
+│       └── agents/generic_defender.py   # Reference Purple Agent
+│
+├── Dockerfile                           # Base polyglot image
+├── Dockerfile.green                     # Green Agent standalone
+├── Dockerfile.purple                    # Purple Agent standalone
+├── Dockerfile.sandbox                   # Sandbox execution environment
+│
+├── pyproject.toml                       # Python dependencies (uv)
+├── .env.example                         # Environment template
+└── .github/workflows/ci.yml            # CI pipeline
 ```
 
 ---
 
 ## Research Background
 
-LogoMesh is built on the concept of **Contextual Debt** - a measure of how well AI-generated code maintains alignment with original intent through the development lifecycle.
+LogoMesh is built on the concept of **Contextual Debt** — a measure of how well AI-generated code maintains alignment with original intent through the development lifecycle.
 
 ### Key Concepts
 
-- **Contextual Integrity Score (CIS)** - Quantifies alignment across rationale, architecture, testing, and logic
-- **Decision Bill of Materials (DBOM)** - Cryptographic proof of evaluation decisions
-- **Adversarial Evaluation** - Red Agent stress-tests Purple's code
+- **Contextual Integrity Score (CIS)** — Quantifies alignment across rationale, architecture, testing, and logic dimensions
+- **Decision Bill of Materials (DBOM)** — Cryptographic proof of evaluation decisions, including intent vectors and score hashes
+- **Adversarial Evaluation** — MCTS-powered Red Agent stress-tests code for vulnerabilities
+- **Ground-Truth Scoring** — Scores anchored to real signals (test pass rates, constraint violations) rather than LLM opinion alone
+- **Strategy Evolution** — UCB1 bandit selects evaluation strategies based on cumulative performance data
+- **Battle Memory** — Persistent learning from past evaluations informs future scoring and attack strategies
 
 ### Papers
 
@@ -533,6 +474,5 @@ MIT
 
 ## Links
 
-- [AgentBeats Platform](https://agentbeats.ai)
+- [AgentBeats Platform](https://agentbeats.dev)
 - [A2A Protocol](https://github.com/google/A2A)
-- [Leaderboard Repository](https://github.com/sszz01/logomesh-leaderboard-2)

--- a/docker-compose.agents.yml
+++ b/docker-compose.agents.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+
+services:
+  green:
+    build:
+      context: .
+      dockerfile: Dockerfile.green
+    ports:
+      - "9009:9009"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
+      - RED_AGENT_MCTS=true
+      - RED_AGENT_MAX_STEPS=5
+      - RED_AGENT_TIMEOUT=20
+      - ENABLE_REFINEMENT=true
+      - SANDBOX_TIMEOUT=15
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - battle-data:/app/data
+    command: ["--host", "0.0.0.0", "--port", "9009"]
+
+  purple:
+    build:
+      context: .
+      dockerfile: Dockerfile.purple
+    ports:
+      - "9010:9010"
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o-mini}
+    command: ["--host", "0.0.0.0", "--port", "9010"]
+
+volumes:
+  battle-data:


### PR DESCRIPTION
- Rewrite README with abstract, architecture diagram, ground-truth scoring methodology, reproducibility section, and full env var docs
- Add docker-compose.agents.yml for Green + Purple agent orchestration
- Update .env.example with all configurable environment variables
- Document novel task support, intent-code mismatch detection, strategy evolution, and battle memory systems
- Fix port numbers, project structure, and scoring pipeline description