### PR TITLE
Add pre-submission review document

### DIFF
--- a/docs/04-Operations/Intent-Log/Technical/20260205-Pre-Submission-Review.md
+++ b/docs/04-Operations/Intent-Log/Technical/20260205-Pre-Submission-Review.md
@@ -1,0 +1,62 @@
+# Pre-Submission Review: LogoMesh (AgentBeats Competition)
+
+**Date:** 2026-02-05
+**Reviewer:** Jules (Judge Persona)
+**Status:** High-Level Pre-Submission Audit
+
+## Executive Summary
+The repository is in a strong state for submission. The core logic (`src/`) is well-structured, the documentation (`README.md` and `docs/`) is comprehensive, and the entry points are clear. However, the root directory contains significant "cruft" (logs, scripts, artifacts) that should be cleaned up to present a polished submission. Additionally, a critical artifact (`leaderboard.json`) appears to be missing.
+
+---
+
+## 1. README.md
+**Status:** ✅ **Excellent**
+- The `README.md` is comprehensive, serving as the primary entry point.
+- It clearly defines the project ("LogoMesh"), the problem it solves (Contextual Debt), and provides Quick Start instructions.
+- It correctly links to `docs/` for deeper dives.
+
+## 2. The Abstract
+**Status:** ✅ **Found**
+- **Project Abstract:** Located directly in `README.md` under the "Abstract" header.
+- **Theoretical Abstract:** For the underlying theory, refer to `docs/00-Strategy/IP/Contextual-Debt-Paper.md`.
+- **Recommendation:** No action needed; the abstract is well-placed for judges.
+
+## 3. Code & Repository Structure
+**Status:** ⚠️ **Cleanup Required**
+The root directory is cluttered with development artifacts that distract from the submission.
+
+**Action Items:**
+1.  **Move to `tests/` or `scripts/`**:
+    - `mock_purple.py` -> `tests/mock_purple.py`
+    - `verify_persistence.py` -> `tests/verify_persistence.py`
+    - `run_arena_test.sh` -> `scripts/run_arena_test.sh` (or delete if obsolete)
+2.  **Move to `docs/Archive/`**:
+    - `Session-Log-20260131.md` -> `docs/Archive/Logs/Technical/`
+    - `20260127-Session-Review-Video-Plan-and-Cleanup.md` -> `docs/Archive/Logs/Technical/`
+    - `agentbeats-competition-info-session-deck.pdf` -> `docs/Archive/Assets/`
+    - `Dual-Track-Arena-Doc-Update-Plan-20260130.md` -> `docs/Archive/Plans/`
+3.  **Review for Redundancy**:
+    - `how_to_use_agentbeats.md`: This document describes the `agentbeats` SDK/CLI usage, while `README.md` describes the `LogoMesh` benchmark usage.
+        - **Recommendation:** Clarify the relationship in the header of `how_to_use_agentbeats.md` (e.g., "This guide is for building agents using the SDK") or move it to `docs/SDK-Reference/`.
+
+## 4. External Folder (`external/`)
+**Status:** ✅ **Safe to Delete**
+- The `external/logomesh-leaderboard-2` directory is a template repo.
+- **Verification:** A grep search confirms no code in `src/` or `main.py` depends on this directory.
+- **Recommendation:** Proceed with deletion before final submission as requested.
+
+## 5. Missing Critical Items
+**Status:** ❌ **Action Required**
+- **`leaderboard.json`**: The memory context indicates the submission *requires* a `leaderboard.json` file containing DuckDB SQL queries for scoring.
+    - **Finding:** `find . -name "leaderboard.json"` returned no results.
+    - **Impact:** Without this, the automated scoring pipeline on the competition platform may fail.
+    - **Action:** Create `leaderboard.json` defining the Contextual Integrity Score (CIS) calculation.
+
+## 6. Other Observations
+- **Naming Consistency:** `pyproject.toml` names the project `agentbeats-tutorial`, but the README calls it `LogoMesh`. This is cosmetic but worth noting if `pip install` behaviors matter.
+- **Judges Guide:** `docs/05-Competition/Judges-Start-Here.md` is an excellent resource and should be highlighted in the final submission notes.
+- **Links:** Links in `Judges-Start-Here.md` to `Purple-Agent-Detailed-Guide.md` and `Green-Agent-Detailed-Guide.md` are valid (files exist in the same directory).
+
+## Final Verdict
+**PASS with Conditions.**
+The submission is technically sound but requires a final "janitorial" pass to remove root-level clutter and the addition of the missing `leaderboard.json` file.


### PR DESCRIPTION
Added `docs/04-Operations/Intent-Log/Technical/20260205-Pre-Submission-Review.md` which summarizes findings from a high-level audit of the repository ahead of the final competition submission. Key findings include cleanup of root directory artifacts and the requirement to add a missing `leaderboard.json` file. No code changes were made.