### PR TITLE
docs: Finalize dual-track Lambda strategy across all Phase 2 docs

### DIFF
--- a/docs/06-Phase-2/Planning_and_Strategy/Strategic_Academic_Integration_Reference.md
+++ b/docs/06-Phase-2/Planning_and_Strategy/Strategic_Academic_Integration_Reference.md
@@ -1,11 +1,11 @@
 # Strategic Academic Integration Reference
-*Extracted from the obsolete "[2026-03-03] LogoMesh Phase 2 Planning & Meeting.md"*
+*Extracted from the "[2026-03-03] LogoMesh Phase 2 Planning & Meeting.md"*
 
 This document preserves the valuable theoretical concepts proposed for the NeurIPS 2026 submission, specifically regarding the integration of Professor Tianyu Shi's research frameworks into the LogoMesh architecture.
 
 ## 1. DynaWeb: Model-Based Reinforcement Learning via Imagination
 
-The DynaWeb framework, originally designed for Web Agents, provides a solution for constrained environments (like the former Lambda track plan) and can be adapted for generalized evaluation.
+The DynaWeb framework, originally designed for Web Agents, provides a solution for constrained environments (like the active Lambda track "Offline Sandbox" strategy) and can be adapted for generalized evaluation.
 
 *   **Concept:** DynaWeb uses a "Web World Model" (WWM) as a synthetic proxy for the real environment. The agent policy interacts with this simulated world instead of making expensive live API calls.
 *   **Mechanism:** The WWM predicts natural language descriptions of state changes based on current observations and agent actions, leveraging LLM instruction-following.

--- a/docs/06-Phase-2/Planning_and_Strategy/[2026-03-03] [post-meeting-brief] Phase 2 Strategic Realignment & Academic Dynamics.md
+++ b/docs/06-Phase-2/Planning_and_Strategy/[2026-03-03] [post-meeting-brief] Phase 2 Strategic Realignment & Academic Dynamics.md
@@ -20,7 +20,7 @@ Your previous document \[2026-03-01\] Sprint 3 Discovery & Blind Spots.md was fa
 * **Sprint 2 (March 16 – April 5):** Agent Safety, **Cybersecurity Agent**, Software Testing Agent, Finance Agent.  
 * **Sprint 3 (April 6 – April 26):** Multi-Agent Evaluation, **Coding Agent**, Healthcare Agent.
 
-**The Pivot:** During the March 4 meeting, your team agreed to target the **Cybersecurity Agent track**.
+**The Pivot:** During the March 4 meeting, your team agreed to target the **Cybersecurity Agent track**, while also maintaining the **Lambda Custom Track** as part of a dual-track strategy.
 
 * **The Problem:** Because Cybersecurity is in Sprint 2, not Sprint 3, you have lost three weeks of assumed preparation time. The sprint begins on March 16\. You have less than two weeks to refactor LogoMesh.  
 * **The Advantage:** The Phase 1 winner in the Cybersecurity track is Ethernaut Arena, which requires auditing and exploiting Solidity smart contracts. Because Prof. Shi's team literally wrote the paper *EVM-Bench* (Ethereum Virtual Machine Benchmark), your academic partners are uniquely qualified to defeat this specific Green Agent.
@@ -41,7 +41,7 @@ If you are pivoting to Cybersecurity and processing real exploits (like C/C++ fu
 
 **D. Compute Allocation**
 
-You have $500 in Lambda compute credits and OpenAI API access. Given the 4-call limit in the Lambda custom track, use these credits exclusively to run offline, mass-simulated MCTS tree expansions to farm the optimal prompt injection paths locally, as planned. Do not waste live API calls on platform tests that will fail the hard limit.
+You have Lambda compute credits and OpenAI API access. Given the 4-call limit in the Lambda custom track, use these credits (starting with local micro-LLMs and scaling to H100s) exclusively to run offline, mass-simulated MCTS tree expansions and micro-telemetry to farm the optimal prompt injection paths locally, as planned. Do not waste live API calls on platform tests that will fail the hard limit.
 
 ## **4\. Linear Pipeline & Academic Sync**
 

--- a/docs/06-Phase-2/Planning_and_Strategy/[2026-03-04] Red_Agent_Remediation_Plan.md
+++ b/docs/06-Phase-2/Planning_and_Strategy/[2026-03-04] Red_Agent_Remediation_Plan.md
@@ -51,7 +51,7 @@ The safest and most performant pivot is to externalize the untrusted execution t
 ### 4. Adapt Red Agent for Cybersecurity Track Targets (P1)
 
 **Context:**
-The team has officially pivoted from the Lambda track to the Cybersecurity Agent track (Sprint 3). The Red Agent's logic must be updated to target specific vulnerabilities found in Solidity smart contracts and C/C++ memory implementations.
+The team is operating a dual-track approach. For the Cybersecurity Agent track (Sprint 3) on the `main-generalized-phase2` branch, the Red Agent's logic must be updated to target specific vulnerabilities found in Solidity smart contracts and C/C++ memory implementations. For the Lambda Custom Track on the `main-lambda-phase2` branch, the Red Agent relies on an "Offline Sandbox" approach to pre-calculate attacks locally.
 
 **Implementation Plan:**
 *   **Target Files:** `src/red_logic/orchestrator.py`, `src/task_intelligence.py`

--- a/docs/06-Phase-2/README.md
+++ b/docs/06-Phase-2/README.md
@@ -2,13 +2,15 @@
 
 Welcome to the definitive source of truth for the LogoMesh project's Phase 2 development. This documentation hub has been synthesized, analyzed, and reorganized to provide clear strategic direction and actionable intelligence for the AgentBeats competition and our subsequent NeurIPS 2026 submission.
 
-## Strategic Overview & The "Cybersecurity Pivot"
+## Strategic Overview & The Dual-Track Approach
 
-Following our Phase 1 victory in the Software Testing Agent track, LogoMesh faced significant architectural challenges entering Phase 2. Initial plans to target the **Lambda Custom Track** were abandoned after discovering a restrictive 4-call LLM limit that rendered our live Monte Carlo Tree Search (MCTS) engine mathematically impossible to execute.
+Following our Phase 1 victory in the Software Testing Agent track, LogoMesh faced significant architectural challenges entering Phase 2. Initial plans to target the **Lambda Custom Track** faced a hurdle with a restrictive 4-call LLM limit. However, we have adopted a dual-track strategy to actively pursue both the Cybersecurity Agent track and the Lambda Custom Track.
 
-After establishing a strategic academic partnership with Professor Tianyu Shi (McGill University) and researcher Yichen "Ethan" Shen, the team successfully pivoted. Leveraging Prof. Shi's team's expertise in "EVM-Bench" (Ethereum Virtual Machine benchmarking), we are now exclusively targeting the **Cybersecurity Agent track** for Sprint 3 (April 13 – May 3, 2026).
+After establishing a strategic academic partnership with Professor Tianyu Shi (McGill University) and researcher Yichen "Ethan" Shen, we are heavily leveraging Prof. Shi's team's expertise in "EVM-Bench" (Ethereum Virtual Machine benchmarking).
 
-If successful in adapting our Red Agent to handle Cybersecurity targets (like Solidity smart contracts and C/C++ memory vulnerabilities), we will subsequently expand our focus to the Coding Agent track.
+We are operating on two separate branches:
+*   **`main-generalized-phase2`**: Dedicated to adapting our Red Agent to handle Cybersecurity targets (like Solidity smart contracts and C/C++ memory vulnerabilities) for Sprint 3 (April 13 – May 3, 2026).
+*   **`main-lambda-phase2`**: Dedicated to the Lambda Custom Track. Here, we utilize an "Offline Sandbox" strategy. We bypass the 4-call limit by running our MCTS and micro-telemetry offline (using local micro-LLMs and scaling to H100s via Lambda compute credits) to simulate battles and calculate highly optimized attack prompts. The final submission will be a lightweight script executing these pre-calculated attacks.
 
 ## Directory Structure & Navigation
 
@@ -16,7 +18,7 @@ This directory has been restructured to separate active, actionable intelligence
 
 *   **`README.md`**: The definitive single source of truth for Phase 2 strategy.
 *   **`Action_Items.md`**: A consolidated list of Priority 0 (Urgent) to Priority 2 (Medium) tasks, fully prepared for import into our Linear project management tool.
-*   **`Strategic_Timeline.md`**: A detailed chronological trace of our strategy evolution, detailing the "Offline Sandbox" pivot and the final decision to focus on the Cybersecurity track, abandoning the Lambda track.
+*   **`Strategic_Timeline.md`**: A detailed chronological trace of our strategy evolution, detailing the "Offline Sandbox" pivot, the Cybersecurity track integration, and the dual-track execution plan.
 *   **`Risks_and_Blind_Spots.md`**: A comprehensive assessment of our current operational and architectural vulnerabilities, prominently featuring the "Uroboros" security threat and critical cryptographic hashing discrepancies.
 *   **`[2026-02-28] Architecture-Overview.md`**: (Core Historical) A code-derived overview of the LogoMesh system architecture at the end of Phase 1.
 *   **`Planning_and_Strategy/`**: Contains foundational documents outlining the theoretical frameworks (DynaWeb, CCMA) proposed for integrating our academic partners and structuring our NeurIPS submission, as well as concrete remediation plans like [[2026-03-04] Red_Agent_Remediation_Plan.md](./Planning_and_Strategy/[2026-03-04]%20Red_Agent_Remediation_Plan.md) to address our current architectural vulnerabilities.
@@ -29,7 +31,7 @@ This directory has been restructured to separate active, actionable intelligence
 During the synthesis of these documents, several critical contradictions were identified and definitively resolved by the project lead:
 
 1.  **Cybersecurity Track Timeline:** Previous internal briefs incorrectly stated the Cybersecurity track was in Sprint 2. The definitive timeline, as confirmed by the official AgentBeats schedule, places the **Cybersecurity Agent track in Sprint 3 (April 13 – May 3, 2026)**.
-2.  **Definitive Track Decision:** While some meeting summaries suggested indecision between the Cybersecurity and Coding tracks, it has been formally decided to focus **solely on the Cybersecurity Agent track** first.
+2.  **Definitive Track Decision:** While some meeting summaries suggested indecision between the Cybersecurity and Coding tracks, or a complete abandonment of the Lambda track, it has been formally decided to adopt a **dual-track focus**. We are pursuing the Cybersecurity Agent track on `main-generalized-phase2` and the Lambda track on `main-lambda-phase2` simultaneously.
 3.  **Role Assignments (Ethan vs. Engineering):** The raw transcripts and meeting minutes confirm that **Yichen "Ethan" Shen** will focus on algorithm design and literature review. **Oleksandr and the internal engineering team** remain responsible for the actual code adaptation of the Red Agent. Ethan will be briefed on the repository structure before specific implementation tasks are assigned.
 4.  **Bakul's Status:** Bakul has formally resolved any previous conflicts of interest related to the Lambda track and remains fully engaged in adapting LogoMesh for the Phase 2 sprints.
 

--- a/docs/06-Phase-2/Strategic_Timeline.md
+++ b/docs/06-Phase-2/Strategic_Timeline.md
@@ -3,7 +3,7 @@
 ## Phase 1 Conclusion & Initial Evaluation
 - **October 2025 - January 2026:** LogoMesh successfully completes Phase 1 of the AgentX-AgentBeats competition, securing first place in the Software Testing Agent track by developing a robust "Green Agent" (evaluator) that utilizes an embedded "Red Agent" (MCTS-based attacker) to find vulnerabilities in submitted code.
 
-## Early Phase 2 Strategy: The Lambda Track (Now Obsolete)
+## Lambda Track Strategy Evolution
 - **February 23, 2026:** The Lambda Agent Security custom track begins. This track focuses on red-teaming and automated security testing, operating on a fast-tracked timeline with a deadline of March 30, 2026.
 - **February 28, 2026:** Kickoff Meeting (Josh, Mark, Bakul).
   - The team initially plans to target the Lambda track.
@@ -18,11 +18,15 @@
 - **March 3, 2026:** The Pivotal Meeting with Dr. Shi & Ethan.
   - During the meeting, the timeline and the team's strengths are re-evaluated. The Lambda track deadline (March 30) is deemed too tight for a meaningful academic contribution.
   - Prof. Shi notes his team's previous success publishing "EVM-Bench," an Ethereum Virtual Machine benchmark that sits at the intersection of coding agents and cybersecurity.
-  - **The Second Pivot (Cybersecurity Focus):** The team collectively decides to abandon the Lambda Custom Track entirely. They will formally pivot their Phase 2 efforts to target the **Cybersecurity Agent track**. If successful, they plan to expand to the Coding Agent track later in the sprint.
+  - **The Second Pivot (Cybersecurity Focus):** The team collectively decided to pivot their Phase 2 efforts to target the **Cybersecurity Agent track** as well. The "Offline Sandbox" plan for the Lambda track was temporarily paused but has since been revived on a separate branch.
 
-## The Current Reality: Sprint 3 Cybersecurity
-- **Present Day:** The official Phase 2 Schedule places the Cybersecurity track in **Sprint 3 (April 13 – May 3, 2026)**, alongside Agent Safety and the Coding Agent tracks.
-- This schedule provides the team with approximately six weeks to:
+## The Current Reality: Dual-Track Execution
+- **Present Day:** The official Phase 2 Schedule places the Cybersecurity track in **Sprint 3 (April 13 – May 3, 2026)**, alongside Agent Safety and the Coding Agent tracks. The Lambda track has a deadline of **March 30, 2026**.
+- The team is operating a dual-track approach:
+  - **Lambda Track (`main-lambda-phase2`):** Actively pursuing the "Offline Sandbox" strategy. The goal is to bypass the 4-call limit using local micro-LLMs and H100s via compute credits to simulate battles and prepare pre-calculated attack scripts before the March 30 deadline.
+  - **Cybersecurity Track (`main-generalized-phase2`):** Actively adapting to specific vulnerabilities tested by the Phase 1 Cybersecurity Green Agents (like Ethernaut Arena and RCA-Bench).
+- This dual-track approach gives the team a timeline to:
   1. Fix the critical "Uroboros" security flaw (air-gapping the Red Agent).
-  2. Adapt the existing Red Agent's logic to handle the specific vulnerabilities tested by the Phase 1 Cybersecurity Green Agents (like Ethernaut Arena and RCA-Bench).
-  3. Prepare the data pipeline for the NeurIPS Croissant metadata format.
+  2. Continue offline simulation experiments to refine Lambda track entries.
+  3. Adapt the existing Red Agent's logic to handle Cybersecurity domain targets.
+  4. Prepare the data pipeline for the NeurIPS Croissant metadata format.

--- a/docs/06-Phase-2/[2026-03-04] Ethan_Onboarding_Brief.md
+++ b/docs/06-Phase-2/[2026-03-04] Ethan_Onboarding_Brief.md
@@ -8,9 +8,9 @@ This document serves as your primary reference for our current strategy and tech
 
 Based on the meetings from March 3rd and 4th, we have made a crucial change in our competition strategy.
 
-*   **Abandoned Track:** We are no longer targeting the Lambda Custom Track (deadline: March 30). We discovered that its hard limit of 4 LLM API calls per battle fundamentally breaks our live Monte Carlo Tree Search (MCTS) evaluation engine.
-*   **New Target:** We are now exclusively targeting the **Cybersecurity Agent track**.
-*   **Timeline:** According to the official AgentBeats schedule, the Cybersecurity Agent track takes place during **Sprint 3 (April 13 – May 3, 2026)**. We have approximately six weeks to prepare.
+*   **Dual-Track Strategy (Lambda Track):** While our live Monte Carlo Tree Search (MCTS) evaluation engine is constrained by the 4 LLM API call limit of the Lambda Custom Track, we are maintaining a separate branch (`main-lambda-phase2`) for it. We are using an "Offline Sandbox" strategy—leveraging micro-LLMs and H100s via compute credits to simulate battles and prepare pre-calculated attack scripts before the March 30 deadline.
+*   **Cybersecurity Target:** Our primary focus for the academic integration remains the **Cybersecurity Agent track**, functioning on the `main-generalized-phase2` branch.
+*   **Timeline:** According to the official AgentBeats schedule, the Cybersecurity Agent track takes place during **Sprint 3 (April 13 – May 3, 2026)**. We have approximately six weeks to prepare for this track.
 
 This pivot aligns perfectly with your team's previous success in publishing EVM-Bench, as the Phase 1 winner in the Cybersecurity track (Ethernaut Arena) focuses on auditing and exploiting Solidity smart contracts.
 

--- a/docs/06-Phase-2/[2026-03-04] Red_Agent_Remediation_Plan.md
+++ b/docs/06-Phase-2/[2026-03-04] Red_Agent_Remediation_Plan.md
@@ -51,7 +51,7 @@ The safest and most performant pivot is to externalize the untrusted execution t
 ### 4. Adapt Red Agent for Cybersecurity Track Targets (P1)
 
 **Context:**
-The team has officially pivoted from the Lambda track to the Cybersecurity Agent track (Sprint 3). The Red Agent's logic must be updated to target specific vulnerabilities found in Solidity smart contracts and C/C++ memory implementations.
+The team is operating a dual-track approach. For the Cybersecurity Agent track (Sprint 3) on the `main-generalized-phase2` branch, the Red Agent's logic must be updated to target specific vulnerabilities found in Solidity smart contracts and C/C++ memory implementations. For the Lambda Custom Track on the `main-lambda-phase2` branch, the Red Agent relies on an "Offline Sandbox" approach to pre-calculate attacks locally.
 
 **Implementation Plan:**
 *   **Target Files:** `src/red_logic/orchestrator.py`, `src/task_intelligence.py`


### PR DESCRIPTION
## What does this PR do?

- Updated Ethan_Onboarding_Brief.md and Red_Agent_Remediation_Plan.md to remove claims that the Lambda Custom Track was abandoned.
- Verified all documentation across the Phase 2 folder now consistently reflects the dual-track strategy (`main-generalized-phase2` for Cybersecurity, and `main-lambda-phase2` using the Offline Sandbox and micro-LLMs for the Lambda Custom Track).

## Related issue

n/a

## How was this tested?

Strictly a documentation update, no code testing needed.

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes don't break existing functionality
- [ ] I've tested locally with `make test`
