### PR TITLE
fix: guard ucb1_score against None parent on root node (#139)

### DIFF
--- a/src/red_logic/orchestrator.py
+++ b/src/red_logic/orchestrator.py
@@ -152,7 +152,8 @@ class ThoughtNode:
             return float('inf')  # Unexplored nodes have highest priority
 
         exploitation = self.value / self.visits
-        exploration = exploration_weight * math.sqrt(math.log(self.parent.visits + 1) / self.visits)
+        parent_visits = self.parent.visits + 1 if self.parent else 1
+        exploration = exploration_weight * math.sqrt(math.log(parent_visits) / self.visits)
 
         return exploitation + exploration + (self.prior * 0.5)  # Prior bonus
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,102 @@
+"""Tests for ThoughtNode UCB1 scoring and backpropagation (red_logic.orchestrator)."""
+
+import math
+import pytest
+from red_logic.orchestrator import ThoughtNode
+
+
+def make_node(id="test", parent=None, visits=0, value=0.0, prior=0.5):
+    """Helper to create a ThoughtNode with sensible defaults."""
+    return ThoughtNode(
+        id=id,
+        action={"tool": "test", "parameters": {}, "reasoning": "test"},
+        parent=parent,
+        visits=visits,
+        value=value,
+        prior=prior,
+    )
+
+
+class TestUcb1Score:
+    def test_unvisited_node_returns_inf(self):
+        node = make_node(visits=0)
+        assert node.ucb1_score() == float("inf")
+
+    def test_visited_node_with_parent(self):
+        parent = make_node(id="parent", visits=10)
+        child = make_node(id="child", parent=parent, visits=5, value=3.0)
+        score = child.ucb1_score()
+        # exploitation = 3.0/5 = 0.6
+        # parent_visits = 10 + 1 = 11
+        # exploration = 1.414 * sqrt(ln(11) / 5)
+        # prior bonus = 0.5 * 0.5 = 0.25
+        exploitation = 3.0 / 5
+        exploration = 1.414 * math.sqrt(math.log(11) / 5)
+        expected = exploitation + exploration + 0.25
+        assert abs(score - expected) < 1e-6
+
+    def test_root_node_no_parent_does_not_crash(self):
+        """Regression test for issue #139: root node has parent=None."""
+        root = make_node(id="root", parent=None, visits=3, value=1.5)
+        score = root.ucb1_score()
+        # parent_visits = 1 (fallback), log(1) = 0, so exploration = 0
+        # exploitation = 1.5/3 = 0.5, prior bonus = 0.25
+        assert abs(score - 0.75) < 1e-6
+
+    def test_root_node_after_backpropagation(self):
+        """The exact crash scenario: root gets visits via backpropagate,
+        then ucb1_score is called on it."""
+        root = make_node(id="root", parent=None)
+        child = make_node(id="child", parent=root)
+
+        # Simulate: child is selected, executed, then backpropagates
+        child.backpropagate(0.8)
+
+        # Now root.visits > 0 (backpropagate walked up to root)
+        assert root.visits == 1
+        assert child.visits == 1
+
+        # This was the crash site — root.ucb1_score() with parent=None
+        score = root.ucb1_score()
+        # exploitation = 0.8/1 = 0.8, exploration = 0 (log(1)=0), prior = 0.25
+        assert abs(score - 1.05) < 1e-6
+
+    def test_custom_exploration_weight(self):
+        parent = make_node(id="parent", visits=10)
+        child = make_node(id="child", parent=parent, visits=5, value=2.5)
+        score = child.ucb1_score(exploration_weight=2.0)
+        exploitation = 2.5 / 5
+        exploration = 2.0 * math.sqrt(math.log(11) / 5)
+        expected = exploitation + exploration + 0.25
+        assert abs(score - expected) < 1e-6
+
+
+class TestBackpropagate:
+    def test_single_node(self):
+        node = make_node(visits=0, value=0.0)
+        node.backpropagate(0.5)
+        assert node.visits == 1
+        assert node.value == 0.5
+
+    def test_propagates_to_ancestors(self):
+        root = make_node(id="root")
+        mid = make_node(id="mid", parent=root)
+        leaf = make_node(id="leaf", parent=mid)
+
+        leaf.backpropagate(1.0)
+
+        assert leaf.visits == 1 and leaf.value == 1.0
+        assert mid.visits == 1 and mid.value == 1.0
+        assert root.visits == 1 and root.value == 1.0
+
+    def test_multiple_backpropagations_accumulate(self):
+        root = make_node(id="root")
+        child = make_node(id="child", parent=root)
+
+        child.backpropagate(0.5)
+        child.backpropagate(0.3)
+
+        assert child.visits == 2
+        assert abs(child.value - 0.8) < 1e-9
+        assert root.visits == 2
+        assert abs(root.value - 0.8) < 1e-9


### PR DESCRIPTION
## What does this PR do?

Fixes an `AttributeError` in `src/red_logic/orchestrator.py` where `ucb1_score()` accesses `self.parent.visits` (line 155), but the root node has `parent=None`.

The root node starts with `visits=0`, so the early return on line 151 initially protects it. But `backpropagate()` walks up the tree and increments `visits` on every ancestor including the root. After the first backpropagation, `root.visits > 0`, the early return is skipped, and `self.parent.visits` crashes with `AttributeError: 'NoneType' object has no attribute 'visits'`.

**Fix:** Extract parent visits with a guard: `parent_visits = self.parent.visits + 1 if self.parent else 1`. When parent is `None`, `log(1) = 0` gives zero exploration bonus — mathematically correct for a root node with no parent context. No behavior change for non-root nodes.

Also adds `tests/test_orchestrator.py` with 8 tests covering UCB1 scoring, the exact crash scenario (backpropagate then ucb1_score on root), and backpropagation mechanics.

## Related issue

Fixes #139

## How was this tested?

- `pytest tests/test_orchestrator.py` — 8/8 passed
- `pytest tests/` — all 72 pre-existing passing tests still pass (5 failures in `test_text_mutations.py` are a pre-existing asyncio/Windows issue, unrelated to this change)
- Manual code review confirming `self.parent` is guarded before access

## Checklist

- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My changes don't break existing functionality
- [x] I've tested locally with `make test`

